### PR TITLE
code to interface and use diamond operator to avoid repeating type

### DIFF
--- a/mapreduce/src/main/java/com/marklogic/dom/AttrImpl.java
+++ b/mapreduce/src/main/java/com/marklogic/dom/AttrImpl.java
@@ -27,6 +27,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.TypeInfo;
 
 import com.marklogic.tree.ExpandedTree;
+import java.util.List;
 
 /**
  * A read-only W3C DOM Node implementation of MarkLogic's internal
@@ -120,7 +121,7 @@ public class AttrImpl extends NodeImpl implements Attr {
         int parentNodeRepID = tree.nodeParentNodeRepID[node];
         if (parentNodeRepID == -1)
             parentNodeRepID = node;
-        ArrayList<Integer> ubp = new ArrayList<Integer>();
+        List<Integer> ubp = new ArrayList<>();
         long sum_ordinal = tree.ordinal + tree.nodeOrdinal[parentNodeRepID];
         for (int ns = getNSNodeID(sum_ordinal); ns >= 0; ns = nextNSNodeID(ns,
             0)) {

--- a/mapreduce/src/main/java/com/marklogic/dom/ElementImpl.java
+++ b/mapreduce/src/main/java/com/marklogic/dom/ElementImpl.java
@@ -30,6 +30,7 @@ import org.w3c.dom.TypeInfo;
 
 import com.marklogic.tree.ExpandedTree;
 import com.marklogic.tree.NodeKind;
+import java.util.List;
 
 /**
  * A read-only W3C DOM Node implementation of MarkLogic's internal
@@ -230,7 +231,7 @@ public class ElementImpl extends NodeImpl implements Element {
     protected int getPrefixID(int uriAtom) {
         int a = -1;
         boolean useDefaultNS = true;
-        ArrayList<Integer> ubp = new ArrayList<Integer>();
+        List<Integer> ubp = new ArrayList<>();
         long minOrdinal = 0;
         for (int ns = getNSNodeID(tree.nodeOrdinal[node]); ns >= 0; ns = nextNSNodeID(
             ns, minOrdinal)) {

--- a/mapreduce/src/main/java/com/marklogic/dom/NodeImpl.java
+++ b/mapreduce/src/main/java/com/marklogic/dom/NodeImpl.java
@@ -29,6 +29,7 @@ import org.w3c.dom.UserDataHandler;
 
 import com.marklogic.tree.ExpandedTree;
 import com.marklogic.tree.NodeKind;
+import java.util.List;
 
 /**
  * A read-only W3C DOM Node implementation of MarkLogic's internal
@@ -464,12 +465,12 @@ public abstract class NodeImpl implements Node {
 		final Node thisNode = this;
 		
 		return new NodeList() {
-			protected ArrayList<Node> elementList = new ArrayList<Node>();
+			protected List<Node> elementList = new ArrayList<>();
 			protected boolean done = false;
 			
 			protected void init() {
 				if (done) return;
-				Stack<Node> childrenStack = new Stack<Node>();
+				Stack<Node> childrenStack = new Stack<>();
 				childrenStack.push(thisNode);
 				boolean root = true;
 				while ( !childrenStack.isEmpty()) {

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
@@ -221,12 +221,12 @@ public class ContentOutputFormat<VALUEOUT> extends
     		TaskAttemptContext context) throws IOException{
         Configuration conf = context.getConfiguration();
         Map<String, ContentSource> sourceMap = 
-            new LinkedHashMap<String, ContentSource>();
+            new LinkedHashMap<>();
         if (fastLoad) {
             LinkedMapWritable forestStatusMap = getForestStatusMap(conf);
             // get host->contentSource mapping
             Map<String, ContentSource> hostSourceMap = 
-                new HashMap<String, ContentSource>();
+                new HashMap<>();
             for (Writable v : forestStatusMap.values()) {
                 ForestInfo fs = (ForestInfo)v;
                 //unupdatable forests
@@ -274,7 +274,7 @@ public class ContentOutputFormat<VALUEOUT> extends
         fastLoad = Boolean.valueOf(conf.get(OUTPUT_FAST_LOAD));
         Map<String, ContentSource> sourceMap = getSourceMap(fastLoad, context);
         // construct the ContentWriter
-        return new ContentWriter<VALUEOUT>(conf, sourceMap, fastLoad, am);
+        return new ContentWriter<>(conf, sourceMap, fastLoad, am);
     }
     
     // forest host map is saved when checkOutputSpecs() is called.  In certain 

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -99,7 +99,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
     /**
      * URIs of the documents in a batch.
      */
-    protected HashMap<Content, DocumentURI>[] pendingUris;
+    protected Map<Content, DocumentURI>[] pendingUris;
     
     /**
      * URIs of the documents to be committed.
@@ -148,7 +148,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
     /** role-id -> role-name mapping **/
     protected LinkedMapWritable roleMap;
     
-    protected HashMap<String,ContentPermission[]> permsMap;
+    protected Map<String,ContentPermission[]> permsMap;
     
     protected int succeeded = 0;
     
@@ -181,7 +181,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
         requestOptions = new RequestOptions();
         requestOptions.setMaxAutoRetry(0);
         
-        permsMap = new HashMap<String,ContentPermission[]>();
+        permsMap = new HashMap<>();
         
         int srcMapSize = forestSourceMap.size();
         forestIds = new String[srcMapSize];
@@ -200,7 +200,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
         
         pendingUris = new HashMap[arraySize];
         for (int i = 0; i < arraySize; i++) {
-            pendingUris[i] = new HashMap<Content, DocumentURI>();
+            pendingUris[i] = new HashMap<>();
         }
 
         if (fastLoad
@@ -246,7 +246,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
                 }
                 if (capability != null) {
                     if (permissions == null) {
-                        permissions = new ArrayList<ContentPermission>();
+                        permissions = new ArrayList<>();
                     }
                     permissions.add(new ContentPermission(capability, roleName));
                 }
@@ -304,7 +304,7 @@ extends MarkLogicRecordWriter<DocumentURI, VALUEOUT> implements MarkLogicConstan
         if (needCommit) {
             commitUris = new ArrayList[arraySize];
             for (int i = 0; i < arraySize; i++) {
-                commitUris[i] = new ArrayList<DocumentURI>(txnSize*batchSize);
+                commitUris[i] = new ArrayList<>(txnSize*batchSize);
             }
         }
         

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/DocumentInputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/DocumentInputFormat.java
@@ -42,6 +42,6 @@ extends MarkLogicInputFormat<DocumentURI, VALUEIN> {
     public RecordReader<DocumentURI, VALUEIN> createRecordReader(
             InputSplit split, TaskAttemptContext context) throws IOException,
             InterruptedException {
-        return new DocumentReader<VALUEIN>(context.getConfiguration());
+        return new DocumentReader<>(context.getConfiguration());
     }
 }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/DocumentURI.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/DocumentURI.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.io.WritableComparable;
 
 import com.marklogic.mapreduce.utilities.InternalUtilities;
 import com.marklogic.mapreduce.utilities.LegacyAssignmentPolicy;
+import java.util.Map;
 
 /**
  * Document URI, used as a key for a document record. Use with
@@ -121,7 +122,7 @@ implements WritableComparable<DocumentURI>, Cloneable {
     }
     
     public static void main(String[] args) throws URISyntaxException {
-        HashMap<String, DocumentURI> map = new HashMap<String, DocumentURI>();
+        Map<String, DocumentURI> map = new HashMap<>();
         for (String arg : args) {
             URI uri = new URI(null, null, null, 0, arg, null, null);
             System.out.println("URI encoded: " + uri.toString());

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ForestDocument.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ForestDocument.java
@@ -35,6 +35,7 @@ import com.marklogic.tree.ExpandedTree;
 import com.marklogic.tree.NodeKind;
 import com.marklogic.xcc.Content;
 import com.marklogic.xcc.ContentCreateOptions;
+import java.util.Set;
 
 /**
  * A {@link MarkLogicDocument} retrieved from a MarkLogic forest through 
@@ -122,7 +123,7 @@ public abstract class ForestDocument implements MarkLogicDocument {
         int numMetadata = in.readInt();
         if (numMetadata > 0) {
             String[] metaStrings = WritableUtils.readStringArray(in);
-            metadata = new HashMap<String, String>(numMetadata);
+            metadata = new HashMap<>(numMetadata);
             for (int i = 0; i < metaStrings.length - 1; i++) {
                 metadata.put(metaStrings[i], metaStrings[i + 1]);
             }
@@ -186,7 +187,7 @@ public abstract class ForestDocument implements MarkLogicDocument {
             if (cols == null || cols.length == 0) {
                 options.setCollections(collections);
             } else { // merge
-                HashSet<String> colsSet = new HashSet<String>();
+                Set<String> colsSet = new HashSet<>();
                 if (cols != null) {
                     for (String col : cols) {
                         colsSet.add(col);

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ForestInputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ForestInputFormat.java
@@ -72,7 +72,7 @@ implements MarkLogicConstants {
     public RecordReader<DocumentURIWithSourceInfo, VALUE> createRecordReader(
             InputSplit split, TaskAttemptContext context) throws IOException,
             InterruptedException {
-        return new ForestReader<VALUE>();
+        return new ForestReader<>();
     }
 
     protected List<FileStatus> listStatus(JobContext job) throws IOException {
@@ -101,7 +101,7 @@ implements MarkLogicConstants {
         long maxSize = getMaxSplitSize(job);
         
         // generate splits
-        List<InputSplit> splits = new ArrayList<InputSplit>();
+        List<InputSplit> splits = new ArrayList<>();
         List<FileStatus> files = listStatus(job);
         for (FileStatus file : files) { // stand directories
             Path path = file.getPath();

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ForestReader.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ForestReader.java
@@ -141,7 +141,7 @@ implements MarkLogicConstants {
                 String newDir = dir + "/";
                 it.remove();
                 if (addedDirs == null) {
-                    addedDirs = new ArrayList<String>();
+                    addedDirs = new ArrayList<>();
                 }
                 addedDirs.add(newDir);
             }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/KeyValueInputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/KeyValueInputFormat.java
@@ -49,7 +49,7 @@ implements MarkLogicConstants {
     public RecordReader<KEYIN, VALUEIN> createRecordReader(InputSplit split,
             TaskAttemptContext context) 
     throws IOException, InterruptedException {
-        return new KeyValueReader<KEYIN, VALUEIN>(context.getConfiguration());
+        return new KeyValueReader<>(context.getConfiguration());
     }
 
 }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/KeyValueOutputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/KeyValueOutputFormat.java
@@ -43,7 +43,7 @@ public class KeyValueOutputFormat<KEYOUT, VALUEOUT> extends
         Configuration conf = context.getConfiguration();
         TextArrayWritable hosts = getHosts(conf);
         String host = InternalUtilities.getHost(hosts);
-        return new KeyValueWriter<KEYOUT, VALUEOUT>(conf, host);
+        return new KeyValueWriter<>(conf, host);
     }
 
     @Override

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/LinkedMapWritable.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/LinkedMapWritable.java
@@ -38,7 +38,7 @@ implements Map<Writable, Writable> {
     
     public LinkedMapWritable() {
         super();
-        this.instance = new LinkedHashMap<Writable, Writable>();
+        this.instance = new LinkedHashMap<>();
     }
 
     /** {@inheritDoc} */

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
@@ -259,7 +259,7 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
         }
         
         // fetch data from server
-        List<ForestSplit> forestSplits = new ArrayList<ForestSplit>();
+        List<ForestSplit> forestSplits = new ArrayList<>();
         Session session = null;
         ResultSequence result = null;            
         
@@ -301,7 +301,7 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
             }
             List<String> ruleUris = null;
             if (redactionRuleCol != null) {
-                ruleUris = new ArrayList<String>();
+                ruleUris = new ArrayList<>();
             }
             getForestSplits(jobContext, result, forestSplits, ruleUris);            
             LOG.info("Fetched " + forestSplits.size() + 
@@ -327,12 +327,12 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
         
         // create a split list per forest per host
         if (forestSplits == null || forestSplits.isEmpty()) {
-            return new ArrayList<InputSplit>();
+            return new ArrayList<>();
         }
         
         // construct a list of splits per forest per host
         Map<String, List<List<InputSplit>>> hostForestSplits = 
-            new HashMap<String, List<List<InputSplit>>>();
+            new HashMap<>();
         boolean tsQuery = (jobConf.get(INPUT_QUERY_TIMESTAMP) != null);
         for (int i = 0; i < forestSplits.size(); i++) {
             ForestSplit fsplit = forestSplits.get(i);
@@ -341,10 +341,10 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
                 String host = fsplit.hostName;
                 List<List<InputSplit>> splitLists = hostForestSplits.get(host);
                 if (splitLists == null) {
-                    splitLists = new ArrayList<List<InputSplit>>();
+                    splitLists = new ArrayList<>();
                     hostForestSplits.put(host, splitLists);
                 }
-                splits = new ArrayList<InputSplit>();
+                splits = new ArrayList<>();
                 splitLists.add(splits);
             } else {
                 continue;
@@ -405,7 +405,7 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
             if (splitLists.size() == 1) {
                 hostSplits[i++] = splitLists.get(0);
             } else {
-                hostSplits[i] = new ArrayList<InputSplit>();
+                hostSplits[i] = new ArrayList<>();
                 boolean more = true;
                 for (int j = 0; more; j++) {
                     more = false;
@@ -421,7 +421,7 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
         }
         
         // mix hostSplits into one
-        List<InputSplit> splitList = new ArrayList<InputSplit>();
+        List<InputSplit> splitList = new ArrayList<>();
         boolean more = true;
         for (int j = 0; more; j++) {
             more = false;

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
@@ -39,6 +39,7 @@ import com.marklogic.xcc.ResultItem;
 import com.marklogic.xcc.ResultSequence;
 import com.marklogic.xcc.Session;
 import com.marklogic.xcc.exceptions.RequestException;
+import java.util.List;
 
 /**
  * MarkLogic-based OutputFormat superclass. Use the provided subclasses, such
@@ -164,7 +165,7 @@ implements MarkLogicConstants, Configurable {
             query.setOptions(options);
             result = session.submitRequest(query);
 
-            ArrayList<Text> hosts = new ArrayList<Text>();
+            List<Text> hosts = new ArrayList<>();
             while (result.hasNext()) {
                 ResultItem item = result.next();
                 String host = item.asString();

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ValueInputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ValueInputFormat.java
@@ -55,7 +55,7 @@ implements MarkLogicConstants {
     public RecordReader<LongWritable, VALUEIN> createRecordReader(
             InputSplit split, TaskAttemptContext context)
     throws IOException, InterruptedException {
-        return new ValueReader<VALUEIN>(context.getConfiguration());
+        return new ValueReader<>(context.getConfiguration());
     }
 
 }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/examples/HelloWorld.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/examples/HelloWorld.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.w3c.dom.Document;
-import org.w3c.dom.Node;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -38,7 +37,7 @@ import com.marklogic.mapreduce.ContentType;
 import com.marklogic.mapreduce.DatabaseDocument;
 import com.marklogic.mapreduce.DocumentInputFormat;
 import com.marklogic.mapreduce.DocumentURI;
-import com.marklogic.mapreduce.MarkLogicNode;
+import java.util.List;
 
 /**
  * Read the first word from each input document, then produce
@@ -104,7 +103,7 @@ public class HelloWorld {
                 Context context
                 ) throws IOException, InterruptedException {        
             // Sort the words
-            ArrayList<String> words = new ArrayList<String>();
+            List<String> words = new ArrayList<>();
             for (Text val : values) {
                 words.add(val.toString());
             }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/examples/LinkCountHDFS.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/examples/LinkCountHDFS.java
@@ -192,7 +192,7 @@ class LinkRecordReader extends RecordReader<IntWritable, Text> {
                     "http://www.mediawiki.org/xml/export-0.4/");
             XPathSelector selector = xpath.compile(PATH_EXPRESSION).load();
             selector.setContextItem(xdmDoc);
-            items = new ArrayList<XdmItem>();
+            items = new ArrayList<>();
             for (XdmItem item : selector) {
                 items.add(item);
             }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/examples/WikiLoader.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/examples/WikiLoader.java
@@ -353,7 +353,7 @@ class WikiReader extends RecordReader<Text, Text> {
         IOException {
             // transform to final output
             int event;
-            path = new LinkedList<String>();
+            path = new LinkedList<>();
             article = null;
             title = null;
 
@@ -530,7 +530,7 @@ class WikiReader extends RecordReader<Text, Text> {
             String path = language + "wiki/"
             + (encodeTitle ? uri.toString() : title);
             if (articles == null) {
-                articles = new ArrayList<Article>();
+                articles = new ArrayList<>();
             }
             articles.add(new Article(path, article));
            

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueMatch.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueMatch.java
@@ -70,7 +70,7 @@ public abstract class ValueMatch extends ValueOrWordMatchFunction {
     
     public static void main(String[] args) {
         ValueMatch matchFunc = new ValueMatchFunction();
-        Collection<String> nsbindings = new ArrayList<String>();
+        Collection<String> nsbindings = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             nsbindings.add(args[i]);
         }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueOrWordMatchFunction.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueOrWordMatchFunction.java
@@ -99,7 +99,7 @@ public abstract class ValueOrWordMatchFunction extends LexiconFunction {
     
     public static void main(String[] args) { 
         UriMatch uriMatchFunc = new UriMatch();
-        Collection<String> nsbindings = new ArrayList<String>();
+        Collection<String> nsbindings = new ArrayList<>();
         System.out.println(uriMatchFunc.getInputQuery(nsbindings, 1, 1000));
     }
 }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValuesOrWordsFunction.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValuesOrWordsFunction.java
@@ -101,7 +101,7 @@ public abstract class ValuesOrWordsFunction extends LexiconFunction {
     
     public static void main(String[] args) {
         Words wordsFunc = new WordsFunction();
-        Collection<String> nsbindings = new ArrayList<String>();
+        Collection<String> nsbindings = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             nsbindings.add(args[i]);
         }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/utilities/AssignmentManager.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/utilities/AssignmentManager.java
@@ -50,8 +50,8 @@ public class AssignmentManager {
             return;
         else
             initialized = true;
-        LinkedHashSet<String> forests = new LinkedHashSet<String>();
-        LinkedHashSet<String> updatableForests = new LinkedHashSet<String>();
+        LinkedHashSet<String> forests = new LinkedHashSet<>();
+        LinkedHashSet<String> updatableForests = new LinkedHashSet<>();
         for (Writable f : map.keySet()) {
             String fId = ((Text) f).toString();
             ForestInfo fs = (ForestInfo) map.get(f);

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/utilities/StatisticalAssignmentPolicy.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/utilities/StatisticalAssignmentPolicy.java
@@ -30,7 +30,7 @@ public class StatisticalAssignmentPolicy extends AssignmentPolicy {
         policy = AssignmentPolicy.Kind.STATISTICAL;
         frmtCount = new long[stats.length];
         this.batch = batch;
-        pq = new PriorityBlockingQueue<Stats>(stats.length);
+        pq = new PriorityBlockingQueue<>(stats.length);
 
         for (int i = 0; i < stats.length; i++) {
             pq.add(new Stats(i, stats[i]));

--- a/mapreduce/src/main/java/com/marklogic/tree/ExpandedTree.java
+++ b/mapreduce/src/main/java/com/marklogic/tree/ExpandedTree.java
@@ -197,7 +197,7 @@ public class ExpandedTree implements Writable {
     
     public Map<String, String> getMetadata() {
         if (numMetadata == 0) return null;
-        Map<String, String> metaMap = new HashMap<String, String>(numMetadata);
+        Map<String, String> metaMap = new HashMap<>(numMetadata);
         for (int i = 0; i < numMetadata; i++) {
             metaMap.put(atomString(metaKeys[i]), getText(metaVals[i]));
         }

--- a/mapreduce/src/test/java/com/marklogic/AbstractTestCase.java
+++ b/mapreduce/src/test/java/com/marklogic/AbstractTestCase.java
@@ -28,7 +28,7 @@ public class AbstractTestCase extends TestCase {
     String forest;
     String stand;
     int num;
-    static Set<String> expectedMissingNSDecl = new HashSet<String>();
+    static Set<String> expectedMissingNSDecl = new HashSet<>();
     static {
         expectedMissingNSDecl.add("acronym@xmlns=#parent is null#nextSibling is null");
     }
@@ -43,7 +43,7 @@ public class AbstractTestCase extends TestCase {
     // requires to return a collection of arrays
     @Parameters
     public static Collection data() {
-        List<ForestData[]> dataList = new ArrayList<ForestData[]>();
+        List<ForestData[]> dataList = new ArrayList<>();
         ForestData[] ds1 = { new ForestData("src/test/resources/ns-prefix",
             "ns-prefix-forest", "00000001", 23) };
         dataList.add(ds1);
@@ -98,7 +98,7 @@ public class AbstractTestCase extends TestCase {
                     LOG.debug(n.getNodeName());
             }
             if (n.hasAttributes()) {
-                ArrayList<String> list = new ArrayList<String>();
+                List<String> list = new ArrayList<>();
                 sb.append(n.getNodeName()).append("#\n");
                 NamedNodeMap nnMap = n.getAttributes();
                 for (int j = 0; j < nnMap.getLength(); j++) {

--- a/mapreduce/src/test/java/com/marklogic/TestDocumentImpl.java
+++ b/mapreduce/src/test/java/com/marklogic/TestDocumentImpl.java
@@ -105,7 +105,7 @@ public class TestDocumentImpl extends AbstractTestCase {
             //text document failed in parsing as DOM
             if (doc == null) continue;
             expected.append("\n").append(uri).append("\n");
-        	Queue<NodeList> q = new LinkedList<NodeList>();
+        	Queue<NodeList> q = new LinkedList<>();
         	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
         	while (!q.isEmpty()) {
         		NodeList nl = q.poll();
@@ -267,7 +267,7 @@ public class TestDocumentImpl extends AbstractTestCase {
         	NodeList elementsExpected = rootExpected.getElementsByTagName(tags[s]);
         	expected.append("#NUM##").append(elementsExpected.getLength()).
         			append("#").append("\n");
-        	ArrayList<Node> esort = new ArrayList<Node>();
+        	List<Node> esort = new ArrayList<>();
         	for (int j = 0; j < elementsExpected.getLength(); j++) {
         		esort.add(elementsExpected.item(j));
         	}
@@ -285,7 +285,7 @@ public class TestDocumentImpl extends AbstractTestCase {
         	NodeList elementsActual = rootActual.getElementsByTagName(tags[s]);
         	actual.append("#NUM##").append(elementsActual.getLength()).
 			 	append("#").append("\n");
-        	ArrayList<Node> asort = new ArrayList<Node>();
+        	List<Node> asort = new ArrayList<>();
         	for (int j = 0; j < elementsActual.getLength(); j++) {
         		asort.add(elementsActual.item(j));
         	}
@@ -337,7 +337,7 @@ public class TestDocumentImpl extends AbstractTestCase {
             	NodeList elementsExpected = doc.getElementsByTagName(tags[s]);
             	expected.append("#NUM##").append(elementsExpected.getLength()).
             			append("#").append("\n");
-            	ArrayList<Node> esort = new ArrayList<Node>();
+            	List<Node> esort = new ArrayList<>();
             	for (int j = 0; j < elementsExpected.getLength(); j++) {
             		esort.add(elementsExpected.item(j));
             	}
@@ -355,7 +355,7 @@ public class TestDocumentImpl extends AbstractTestCase {
             	NodeList elementsActual = d.getElementsByTagName(tags[s]);
             	actual.append("#NUM##").append(elementsActual.getLength()).
     			 	append("#").append("\n");
-            	ArrayList<Node> asort = new ArrayList<Node>();
+            	List<Node> asort = new ArrayList<>();
             	for (int j = 0; j < elementsActual.getLength(); j++) {
             		asort.add(elementsActual.item(j));
             	}
@@ -411,7 +411,7 @@ public class TestDocumentImpl extends AbstractTestCase {
             	NodeList elementsExpected = rootExpected.getElementsByTagNameNS(nss[n],tags[s]);
             	expected.append("#NUM##").append(elementsExpected.getLength()).
             			append("#").append("\n");
-            	ArrayList<Node> esort = new ArrayList<Node>();
+            	List<Node> esort = new ArrayList<>();
             	for (int j = 0; j < elementsExpected.getLength(); j++) {
             		esort.add(elementsExpected.item(j));
             	}
@@ -429,7 +429,7 @@ public class TestDocumentImpl extends AbstractTestCase {
             	NodeList elementsActual = rootActual.getElementsByTagNameNS(nss[n],tags[s]);
             	actual.append("#NUM##").append(elementsActual.getLength()).
     			 	append("#").append("\n");
-            	ArrayList<Node> asort = new ArrayList<Node>();
+            	List<Node> asort = new ArrayList<>();
             	for (int j = 0; j < elementsActual.getLength(); j++) {
             		asort.add(elementsActual.item(j));
             	}
@@ -540,7 +540,7 @@ public class TestDocumentImpl extends AbstractTestCase {
                 //text document failed in parsing as DOM
                 if (doc == null) continue;        	
                 expected.append("\n").append(uri).append("\n");
-            	Queue<NodeList> q = new LinkedList<NodeList>();
+            	Queue<NodeList> q = new LinkedList<>();
             	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
             	while (!q.isEmpty()) {
             		NodeList nl = q.poll();
@@ -626,7 +626,7 @@ public class TestDocumentImpl extends AbstractTestCase {
                 //text document failed in parsing as DOM
                 if (doc == null) continue;	
                 expected.append("\n").append(uri).append("\n");
-            	Queue<NodeList> q = new LinkedList<NodeList>();
+            	Queue<NodeList> q = new LinkedList<>();
             	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
             	while (!q.isEmpty()) {
             		NodeList nl = q.poll();
@@ -852,8 +852,8 @@ public class TestDocumentImpl extends AbstractTestCase {
                 		+ forest, stand), false);
             assertEquals(num, trees.size());
 
-        Set<String> expectedAttrSet = new HashSet<String>();
-        Set<String> actualAttrSet = new HashSet<String>();
+        Set<String> expectedAttrSet = new HashSet<>();
+        Set<String> actualAttrSet = new HashSet<>();
         for (int i = 0; i < trees.size(); i++) {
             ExpandedTree t = trees.get(i);
             String uri = t.getDocumentURI();
@@ -950,8 +950,8 @@ public class TestDocumentImpl extends AbstractTestCase {
         assertEquals(actual.toString(), clone.toString());
         assertEquals(expected.toString(), clone.toString());
 
-        Set<String> expectedAttrSet = new TreeSet<String>();
-        Set<String> actualAttrSet = new TreeSet<String>();
+        Set<String> expectedAttrSet = new TreeSet<>();
+        Set<String> actualAttrSet = new TreeSet<>();
         for (int i = 0; i < trees.size(); i++) {
             ExpandedTree t = trees.get(i);
             String uri = t.getDocumentURI();

--- a/mapreduce/src/test/java/com/marklogic/TestDocumentImplClone.java
+++ b/mapreduce/src/test/java/com/marklogic/TestDocumentImplClone.java
@@ -105,7 +105,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
             //text document failed in parsing as DOM
             if (doc == null) continue;
             expected.append("\n").append(uri).append("\n");
-        	Queue<NodeList> q = new LinkedList<NodeList>();
+        	Queue<NodeList> q = new LinkedList<>();
         	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
         	while (!q.isEmpty()) {
         		NodeList nl = q.poll();
@@ -267,7 +267,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
         	NodeList elementsExpected = rootExpected.getElementsByTagName(tags[s]);
         	expected.append("#NUM##").append(elementsExpected.getLength()).
         			append("#").append("\n");
-        	ArrayList<Node> esort = new ArrayList<Node>();
+        	List<Node> esort = new ArrayList<>();
         	for (int j = 0; j < elementsExpected.getLength(); j++) {
         		esort.add(elementsExpected.item(j));
         	}
@@ -285,7 +285,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
         	NodeList elementsActual = rootActual.getElementsByTagName(tags[s]);
         	actual.append("#NUM##").append(elementsActual.getLength()).
 			 	append("#").append("\n");
-        	ArrayList<Node> asort = new ArrayList<Node>();
+        	List<Node> asort = new ArrayList<>();
         	for (int j = 0; j < elementsActual.getLength(); j++) {
         		asort.add(elementsActual.item(j));
         	}
@@ -337,7 +337,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
             	NodeList elementsExpected = doc.getElementsByTagName(tags[s]);
             	expected.append("#NUM##").append(elementsExpected.getLength()).
             			append("#").append("\n");
-            	ArrayList<Node> esort = new ArrayList<Node>();
+            	List<Node> esort = new ArrayList<>();
             	for (int j = 0; j < elementsExpected.getLength(); j++) {
             		esort.add(elementsExpected.item(j));
             	}
@@ -355,7 +355,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
             	NodeList elementsActual = d.getElementsByTagName(tags[s]);
             	actual.append("#NUM##").append(elementsActual.getLength()).
     			 	append("#").append("\n");
-            	ArrayList<Node> asort = new ArrayList<Node>();
+            	List<Node> asort = new ArrayList<>();
             	for (int j = 0; j < elementsActual.getLength(); j++) {
             		asort.add(elementsActual.item(j));
             	}
@@ -411,7 +411,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
             	NodeList elementsExpected = rootExpected.getElementsByTagNameNS(nss[n],tags[s]);
             	expected.append("#NUM##").append(elementsExpected.getLength()).
             			append("#").append("\n");
-            	ArrayList<Node> esort = new ArrayList<Node>();
+            	List<Node> esort = new ArrayList<>();
             	for (int j = 0; j < elementsExpected.getLength(); j++) {
             		esort.add(elementsExpected.item(j));
             	}
@@ -429,7 +429,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
             	NodeList elementsActual = rootActual.getElementsByTagNameNS(nss[n],tags[s]);
             	actual.append("#NUM##").append(elementsActual.getLength()).
     			 	append("#").append("\n");
-            	ArrayList<Node> asort = new ArrayList<Node>();
+            	List<Node> asort = new ArrayList<>();
             	for (int j = 0; j < elementsActual.getLength(); j++) {
             		asort.add(elementsActual.item(j));
             	}
@@ -540,7 +540,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
                 //text document failed in parsing as DOM
                 if (doc == null) continue;        	
                 expected.append("\n").append(uri).append("\n");
-            	Queue<NodeList> q = new LinkedList<NodeList>();
+            	Queue<NodeList> q = new LinkedList<>();
             	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
             	while (!q.isEmpty()) {
             		NodeList nl = q.poll();
@@ -624,7 +624,7 @@ public class TestDocumentImplClone extends AbstractTestCase {
                 //text document failed in parsing as DOM
                 if (doc == null) continue;	
                 expected.append("\n").append(uri).append("\n");
-            	Queue<NodeList> q = new LinkedList<NodeList>();
+            	Queue<NodeList> q = new LinkedList<>();
             	if (doc.hasChildNodes()) q.add(doc.getChildNodes());
             	while (!q.isEmpty()) {
             		NodeList nl = q.poll();
@@ -850,8 +850,8 @@ public class TestDocumentImplClone extends AbstractTestCase {
                 		+ forest, stand), false);
             assertEquals(num, trees.size());
 
-        Set<String> expectedAttrSet = new HashSet<String>();
-        Set<String> actualAttrSet = new HashSet<String>();
+        Set<String> expectedAttrSet = new HashSet<>();
+        Set<String> actualAttrSet = new HashSet<>();
         for (int i = 0; i < trees.size(); i++) {
             ExpandedTree t = trees.get(i);
             String uri = t.getDocumentURI();

--- a/mapreduce/src/test/java/com/marklogic/Utils.java
+++ b/mapreduce/src/test/java/com/marklogic/Utils.java
@@ -24,7 +24,7 @@ public class Utils {
     public static final Log LOG = LogFactory.getLog(Utils.class);
     public static List<ExpandedTree> decodeTreeData(File dir, boolean verbose)
         throws IOException {
-        LinkedList<ExpandedTree> treeList = new LinkedList<ExpandedTree>();
+        List<ExpandedTree> treeList = new LinkedList<>();
         File file = new File(dir, "TreeData");
         if (verbose)
             System.out.println(file.getAbsolutePath() + " -> checkTreeData");

--- a/mlcp/src/main/java/com/marklogic/contentpump/AggregateXMLInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/AggregateXMLInputFormat.java
@@ -39,7 +39,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
     @Override
     public RecordReader<DocumentURIWithSourceInfo, Text> createRecordReader(
             InputSplit is, TaskAttemptContext tac) {
-        return new AggregateXMLReader<Text>();
+        return new AggregateXMLReader<>();
     }
  
 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import com.marklogic.contentpump.utilities.FileIterator;
 import com.marklogic.contentpump.utilities.IdGenerator;
+import java.util.Map;
 
 /**
  * Reader for AggregateXMLInputFormat.
@@ -60,8 +61,7 @@ public class AggregateXMLReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
     protected String idName;
     protected String currentId = null;
     private boolean keepGoing = true;
-    protected HashMap<String, Stack<String>> nameSpaces = 
-        new HashMap<String, Stack<String>>();
+    protected Map<String, Stack<String>> nameSpaces = new HashMap<>();
     protected boolean startOfRecord = true;
     protected boolean hasNext = true;
     private boolean newDoc = false;
@@ -183,7 +183,7 @@ public class AggregateXMLReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
                 if (nameSpaces.containsKey(nsDeclPrefix)) {
                     nameSpaces.get(nsDeclPrefix).push(nsDeclUri);
                 } else {
-                    Stack<String> s = new Stack<String>();
+                    Stack<String> s = new Stack<>();
                     s.push(nsDeclUri);
                     nameSpaces.put(nsDeclPrefix, s);
                 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/CombineDocumentInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CombineDocumentInputFormat.java
@@ -53,7 +53,7 @@ extends FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, VALUE> {
     public RecordReader<DocumentURIWithSourceInfo, VALUE> createRecordReader(
             InputSplit split, TaskAttemptContext context) 
             throws IOException, InterruptedException {
-        return new CombineDocumentReader<VALUE>();
+        return new CombineDocumentReader<>();
     } 
     
     @Override
@@ -63,7 +63,7 @@ extends FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, VALUE> {
 
         // generate splits
         List<InputSplit> splits = super.getSplits(job);
-        List<InputSplit> combinedSplits = new ArrayList<InputSplit>();
+        List<InputSplit> combinedSplits = new ArrayList<>();
         CombineDocumentSplit split = null;
         for (InputSplit file: splits) {
             Path path = ((FileSplit)file).getPath();

--- a/mlcp/src/main/java/com/marklogic/contentpump/CombineDocumentSplit.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CombineDocumentSplit.java
@@ -42,14 +42,14 @@ public class CombineDocumentSplit extends InputSplit implements Writable {
     private Set<String> locations;
     
     public CombineDocumentSplit() {
-        splits = new ArrayList<FileSplit>();
-        locations = new HashSet<String>();
+        splits = new ArrayList<>();
+        locations = new HashSet<>();
     }
     
     public CombineDocumentSplit(List<FileSplit> splits) 
     throws IOException, InterruptedException {
         this.splits = splits;
-        locations = new HashSet<String>();
+        locations = new HashSet<>();
         for (InputSplit split : splits) {
             length += split.getLength();
             for (String loc : split.getLocations()) {
@@ -96,7 +96,7 @@ public class CombineDocumentSplit extends InputSplit implements Writable {
     public void readFields(DataInput in) throws IOException {
         // splits
         int splitSize = in.readInt();
-        splits = new ArrayList<FileSplit>();
+        splits = new ArrayList<>();
         for (int i = 0; i < splitSize; i++) {
             Path path = new Path(Text.readString(in));
             long start = in.readLong();
@@ -107,7 +107,7 @@ public class CombineDocumentSplit extends InputSplit implements Writable {
         // length
         length = in.readLong();
         // locations
-        locations = new HashSet<String>();
+        locations = new HashSet<>();
     }
     
     public void write(DataOutput out) throws IOException {

--- a/mlcp/src/main/java/com/marklogic/contentpump/CompressedAggXMLInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CompressedAggXMLInputFormat.java
@@ -35,7 +35,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
     @Override
     public RecordReader<DocumentURIWithSourceInfo, Text> createRecordReader(
         InputSplit split, TaskAttemptContext context) {
-        return new CompressedAggXMLReader<Text>();
+        return new CompressedAggXMLReader<>();
     }
 
     @Override

--- a/mlcp/src/main/java/com/marklogic/contentpump/CompressedDocumentInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CompressedDocumentInputFormat.java
@@ -54,7 +54,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, VALUE> {
 	        return (RecordReader<DocumentURIWithSourceInfo, VALUE>) 
 	            new CompressedStreamingReader();
 	    } else {
-	        return new CompressedDocumentReader<VALUE>();
+	        return new CompressedDocumentReader<>();
 	    }
 	}
 

--- a/mlcp/src/main/java/com/marklogic/contentpump/CompressedRDFInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CompressedRDFInputFormat.java
@@ -48,7 +48,7 @@ public class CompressedRDFInputFormat extends RDFInputFormat {
         } catch (IOException e) {
             throw new IOException("Error creating CompressedRecordReader:" + e.getMessage());
         }
-        return new CompressedRDFReader<Text>(version, roleMap);
+        return new CompressedRDFReader<>(version, roleMap);
     }
 
     @Override

--- a/mlcp/src/main/java/com/marklogic/contentpump/CompressedRDFReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/CompressedRDFReader.java
@@ -135,12 +135,12 @@ public class CompressedRDFReader<VALUEIN> extends RDFReader<VALUEIN> {
         throws IOException {
         if (dataset == null) {
             if (lang == Lang.NQUADS || lang == Lang.TRIG) {
-                rdfIter = new PipedRDFIterator<Quad>();
+                rdfIter = new PipedRDFIterator<>();
                 @SuppressWarnings("unchecked")
                 PipedQuadsStream stream = new PipedQuadsStream(rdfIter);
                 rdfInputStream = stream;
             } else {
-                rdfIter = new PipedRDFIterator<Triple>();
+                rdfIter = new PipedRDFIterator<>();
                 @SuppressWarnings("unchecked")
                 PipedTriplesStream stream = new PipedTriplesStream(rdfIter);
                 rdfInputStream = stream;

--- a/mlcp/src/main/java/com/marklogic/contentpump/ContentWithFileNameWritable.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/ContentWithFileNameWritable.java
@@ -106,7 +106,7 @@ public class ContentWithFileNameWritable<VALUE> implements CustomContent {
             LOG.error("Error parsing file name as URI " + fileName, e);
         }
         if (collections != null) {
-            List<String> optionList = new ArrayList<String>();
+            List<String> optionList = new ArrayList<>();
             Collections.addAll(optionList, collections);
             if (collectionUri != null) {
                 optionList.add(collectionUri);

--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentOutputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentOutputFormat.java
@@ -42,7 +42,7 @@ public class DatabaseContentOutputFormat extends
         fastLoad = Boolean.valueOf(conf.get(OUTPUT_FAST_LOAD));
         Map<String, ContentSource> sourceMap = getSourceMap(fastLoad, context);
         // construct the DatabaseContentWriter
-        return new DatabaseContentWriter<DatabaseDocumentWithMeta>(conf,
+        return new DatabaseContentWriter<>(conf,
             sourceMap, fastLoad, am);
 
     }

--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -95,7 +95,7 @@ public class DatabaseContentReader extends
         copyQuality = conf.getBoolean(MarkLogicConstants.COPY_QUALITY, true);
         copyMetadata = conf.getBoolean(MarkLogicConstants.COPY_METADATA, true);
         currentKey = new DocumentURI();
-        metadataMap = new HashMap<String, DocumentMetadata>();
+        metadataMap = new HashMap<>();
     }
 
     @Override
@@ -414,7 +414,7 @@ public class DatabaseContentReader extends
             XdmItem metaItem  = item.getItem();
             if (metaItem instanceof JsonItem) {
                 JsonNode node = ((JsonItem)metaItem).asJsonNode();
-                metadata.meta = new HashMap<String, String>(node.size());
+                metadata.meta = new HashMap<>(node.size());
                 for (Iterator<String> names = node.fieldNames(); 
                      names.hasNext();) {
                     String key = names.next();

--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
@@ -43,6 +43,7 @@ import com.marklogic.xcc.Session;
 import com.marklogic.xcc.Session.TransactionMode;
 import com.marklogic.xcc.exceptions.RequestException;
 import com.marklogic.xcc.types.ValueType;
+import java.util.Set;
 
 /**
  * MarkLogicRecordWriter that can 
@@ -97,8 +98,7 @@ public class DatabaseContentWriter<VALUE> extends
             }
             if (isCopyColls) {
                 if (opt.getCollections() != null) {
-                    HashSet<String> colSet = 
-                            new HashSet<String>(meta.collectionsList);
+                    Set<String> colSet = new HashSet<>(meta.collectionsList);
                     // union copy_collection and output_collection
                     for (String s : opt.getCollections()) {
                         colSet.add(s);
@@ -111,8 +111,7 @@ public class DatabaseContentWriter<VALUE> extends
             }      
             if (isCopyPerms) {
                 if (opt.getPermissions() != null) {
-                    HashSet<ContentPermission> pSet = 
-                         new HashSet<ContentPermission>(meta.permissionsList);
+                    Set<ContentPermission> pSet =  new HashSet<>(meta.permissionsList);
                     // union of output_permission & copy_permission
                     for (ContentPermission p : opt.getPermissions()) {
                         pSet.add(p);

--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseTransformOutputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseTransformOutputFormat.java
@@ -41,7 +41,7 @@ public class DatabaseTransformOutputFormat extends DatabaseContentOutputFormat {
         fastLoad = Boolean.valueOf(conf.get(OUTPUT_FAST_LOAD));
         Map<String, ContentSource> sourceMap = getSourceMap(fastLoad, context);
         // construct the DatabaseTransformContentWriter
-        return new DatabaseTransformWriter<DatabaseDocumentWithMeta>(conf,
+        return new DatabaseTransformWriter<>(conf,
             sourceMap, fastLoad, am);
     }
 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/DelimitedJSONInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DelimitedJSONInputFormat.java
@@ -39,7 +39,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
     public RecordReader<DocumentURIWithSourceInfo, Text> createRecordReader(
             InputSplit split, TaskAttemptContext context) 
             throws IOException, InterruptedException {
-        return new DelimitedJSONReader<Text>();
+        return new DelimitedJSONReader<>();
     }
 
 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/DelimitedJSONReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DelimitedJSONReader.java
@@ -190,7 +190,7 @@ public class DelimitedJSONReader<VALUEIN> extends
     protected String findUriInJSON(String line) 
     throws JsonParseException, IOException {
         /* Breadth-First-Search */
-        Queue<Object> q = new LinkedList<Object>();
+        Queue<Object> q = new LinkedList<>();
         Object root = mapper.readValue(line.getBytes(), Object.class);
         if (root instanceof Map || root instanceof ArrayList) {
             q.add(root);

--- a/mlcp/src/main/java/com/marklogic/contentpump/DelimitedTextInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DelimitedTextInputFormat.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 import com.marklogic.contentpump.utilities.CSVParserFormatter;
 import com.marklogic.contentpump.utilities.DelimitedSplit;
-import com.marklogic.contentpump.utilities.DocBuilder;
 import com.marklogic.contentpump.utilities.EncodingUtil;
 import com.marklogic.mapreduce.DocumentURIWithSourceInfo;
 import com.marklogic.mapreduce.MarkLogicConstants;
@@ -61,9 +60,9 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
             InputSplit split, TaskAttemptContext context) 
             throws IOException, InterruptedException {
         if (isSplitInput(context.getConfiguration())) {
-            return new SplitDelimitedTextReader<Text>();
+            return new SplitDelimitedTextReader<>();
         } else {
-            return new DelimitedTextReader<Text>();
+            return new DelimitedTextReader<>();
         }
     }
 
@@ -91,11 +90,11 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
             return splits;
         }
         // add header info into splits
-        List<InputSplit> populatedSplits = new ArrayList<InputSplit>();
+        List<InputSplit> populatedSplits = new ArrayList<>();
         LOG.info(splits.size() + " DelimitedSplits generated");
         Configuration conf = job.getConfiguration();
         char delimiter =0;
-        ArrayList<Text> hlist = new ArrayList<Text>();
+        List<Text> hlist = new ArrayList<>();
         for (InputSplit file: splits) {
             FileSplit fsplit = ((FileSplit)file);
             Path path = fsplit.getPath();

--- a/mlcp/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
@@ -47,9 +47,9 @@ public class DocumentMetadata {
     public static String NAKED = ".naked";
     protected DocumentFormat format = DocumentFormat.XML;
 
-    protected List<String> collectionsList = new Vector<String>();
+    protected List<String> collectionsList = new Vector<>();
 
-    protected List<ContentPermission> permissionsList = new Vector<ContentPermission>();
+    protected List<ContentPermission> permissionsList = new Vector<>();
     protected String permString = null;
     protected int quality = 0;
     protected Map<String, String> meta = null;

--- a/mlcp/src/main/java/com/marklogic/contentpump/FileAndDirectoryInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/FileAndDirectoryInputFormat.java
@@ -70,7 +70,7 @@ FileInputFormat<K, V> {
     
     @Override
     public List<InputSplit> getSplits(JobContext job) throws IOException {
-        List<InputSplit> splits = new ArrayList<InputSplit>();
+        List<InputSplit> splits = new ArrayList<>();
         Configuration conf = job.getConfiguration();
         try {
             List<FileStatus> files = listStatus(job);
@@ -132,7 +132,7 @@ FileInputFormat<K, V> {
         }
         
         PathFilter jobFilter = getInputPathFilter(job);
-        List<PathFilter> filters = new ArrayList<PathFilter>();
+        List<PathFilter> filters = new ArrayList<>();
         filters.add(hiddenFileFilter);
         if (jobFilter != null) {
             filters.add(jobFilter);
@@ -204,7 +204,7 @@ FileInputFormat<K, V> {
 
         // creates a MultiPathFilter with the hiddenFileFilter and the
         // user provided one (if any).
-        List<PathFilter> filters = new ArrayList<PathFilter>();
+        List<PathFilter> filters = new ArrayList<>();
         filters.add(hiddenFileFilter);
         PathFilter jobFilter = getInputPathFilter(job);
         if (jobFilter != null) {
@@ -220,8 +220,8 @@ FileInputFormat<K, V> {
 
     private List<FileStatus> simpleListStatus(JobContext job, Path[] dirs,
             PathFilter inputFilter, boolean recursive) throws IOException {
-        List<FileStatus> result = new ArrayList<FileStatus>();
-        List<IOException> errors = new ArrayList<IOException>();
+        List<FileStatus> result = new ArrayList<>();
+        List<IOException> errors = new ArrayList<>();
         Configuration conf = job.getConfiguration();
         for (int i=0; i < dirs.length; ++i) {
             Path p = dirs[i];

--- a/mlcp/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
@@ -179,7 +179,7 @@ implements ConfigConstants {
                 ((ContentWithFileNameWritable<VALUEIN>) value)
                     .setFileName(file.getName());
             } else {
-                Writable cvalue = new ContentWithFileNameWritable<VALUEIN>(
+                Writable cvalue = new ContentWithFileNameWritable<>(
                     (VALUEIN) value, file.getName());
                 value = (VALUEIN) cvalue;
             }

--- a/mlcp/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
@@ -158,12 +158,12 @@ public class LocalJobRunner implements ConfigConstants {
         }
         Monitor monitor = new Monitor();
         monitor.start();
-        List<Future<Object>> taskList = new ArrayList<Future<Object>>();
+        List<Future<Object>> taskList = new ArrayList<>();
         for (int i = 0; i < array.length; i++) {        
             InputSplit split = array[i];
             if (pool != null) {
                 LocalMapTask<INKEY, INVALUE, OUTKEY, OUTVALUE> task = 
-                    new LocalMapTask<INKEY, INVALUE, OUTKEY, OUTVALUE>(
+                    new LocalMapTask<>(
                         inputFormat, outputFormat, conf, i, split, reporter,
                         progress[i]);
                 availableThreads = assignThreads(i, array.length);

--- a/mlcp/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
@@ -190,7 +190,7 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
         try {
 	        List<Future<?>> taskList = null;
 	        if (threadPool != null) {
-            	taskList = new ArrayList<Future<?>>();
+            	taskList = new ArrayList<>();
                 synchronized (threadPool) {
                     for (int i = 0; i < numberOfThreads; ++i) {
                         MapRunner runner = new MapRunner();
@@ -218,7 +218,7 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
                     f.get();
                 }
 	        } else {
-	            runners = new ArrayList<MapRunner>(numberOfThreads);
+	            runners = new ArrayList<>(numberOfThreads);
                 for (int i = 0; i < numberOfThreads; ++i) {
                     MapRunner thread;
                     thread = new MapRunner();

--- a/mlcp/src/main/java/com/marklogic/contentpump/RDFInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/RDFInputFormat.java
@@ -54,7 +54,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, Text> {
         } catch (IOException e) {
             throw new IOException("Error creating RecordReader:" + e.getMessage());
         }
-        return new RDFReader<Text>(version,roleMap);
+        return new RDFReader<>(version,roleMap);
     }
     
     protected LinkedMapWritable getRoleMap(TaskAttemptContext context) throws IOException{

--- a/mlcp/src/main/java/com/marklogic/contentpump/RDFReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/RDFReader.java
@@ -76,6 +76,7 @@ import com.marklogic.xcc.ResultSequence;
 import com.marklogic.xcc.Session;
 import com.marklogic.xcc.exceptions.RequestException;
 import com.marklogic.xcc.exceptions.XccConfigException;
+import java.util.Map;
 
 /**
  * Reader for RDF quads/triples. Uses Jena library to parse RDF and sends triples
@@ -109,8 +110,7 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
     protected PipedRDFStream rdfInputStream;
     protected Lang lang;
 
-    protected Hashtable<String, Vector> collectionHash = 
-            new Hashtable<String, Vector> ();
+    protected Map<String, Vector> collectionHash = new Hashtable<> ();
     protected int collectionCount = 0;
     private static final int MAX_COLLECTIONS = 100;
     protected boolean ignoreCollectionQuad = false;
@@ -137,7 +137,7 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
     protected long ingestedTriples = 0;
     /* new graphs identified within a RDFReader */
     protected HashSet<String> newGraphs;
-    protected HashMap<String,ContentPermission[]> existingMapPerms;
+    protected Map<String,ContentPermission[]> existingMapPerms;
     protected Iterator<String> graphItr;
     /* server version */
     protected String version;
@@ -160,8 +160,8 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
         this.roleMap = roleMap;
         roleMapExists = roleMap!=null && roleMap.size()>0 ;
         graphQry = new StringBuilder();
-        existingMapPerms = new HashMap<String,ContentPermission[]>();
-        newGraphs = new HashSet<String>();
+        existingMapPerms = new HashMap<>();
+        newGraphs = new HashSet<>();
     }
 
     @Override
@@ -355,12 +355,12 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
     protected void loadModel(final String fsname, final InputStream in) throws IOException {
         if (dataset == null) {
             if (lang == Lang.NQUADS || lang == Lang.TRIG) {
-                rdfIter = new PipedRDFIterator<Quad>();
+                rdfIter = new PipedRDFIterator<>();
                 @SuppressWarnings("unchecked")
                 PipedQuadsStream stream = new PipedQuadsStream(rdfIter);
                 rdfInputStream = stream;
             } else {
-                rdfIter = new PipedRDFIterator<Triple>();
+                rdfIter = new PipedRDFIterator<>();
                 @SuppressWarnings("unchecked")
                 PipedTriplesStream stream = new PipedTriplesStream(rdfIter);
                 rdfInputStream = stream;
@@ -577,7 +577,7 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
             while (result.hasNext()) {
                 String uri = result.next().asString();
                 String tmp = result.next().asString();
-                ArrayList<ContentPermission> perms = new ArrayList<ContentPermission>();
+                List<ContentPermission> perms = new ArrayList<>();
                 while(!tmp.equals("0")) {
                     Text roleid = new Text(tmp);
                     if (!result.hasNext()) {
@@ -614,7 +614,7 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
      * return ContentPermission[] for the graph
      */
     public ContentPermission[] insertGraphDoc(String graph) throws IOException {
-        ArrayList<ContentPermission> perms = new ArrayList<ContentPermission>();
+        List<ContentPermission> perms = new ArrayList<>();
             ContentPermission[] permissions = defaultPerms;
             StringBuilder sb = graphQry;
             if (countPerBatch >= MAXGRAPHSPERREQUEST) {

--- a/mlcp/src/main/java/com/marklogic/contentpump/RDFWritable.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/RDFWritable.java
@@ -78,7 +78,7 @@ public class RDFWritable<VALUE> implements CustomContent {
         String outputOverrideGraph = conf.get(MarkLogicConstants.OUTPUT_OVERRIDE_GRAPH);
         
         if (collections != null) {
-            List<String> optionList = new ArrayList<String>();
+            List<String> optionList = new ArrayList<>();
             if (graphUri == null) { //no graph specified in quad
                 if( outputGraph != null)//output_graph is set
                     optionList.add(outputGraph.trim()); 

--- a/mlcp/src/main/java/com/marklogic/contentpump/SequenceFileInputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/SequenceFileInputFormat.java
@@ -36,7 +36,7 @@ FileAndDirectoryInputFormat<DocumentURIWithSourceInfo, VALUE> {
     public RecordReader<DocumentURIWithSourceInfo, VALUE> createRecordReader(
         InputSplit arg0, TaskAttemptContext arg1) throws IOException,
         InterruptedException {
-        return new SequenceFileReader<VALUE>();
+        return new SequenceFileReader<>();
     }
     
 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/TransformOutputFormat.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/TransformOutputFormat.java
@@ -118,7 +118,7 @@ public class TransformOutputFormat<VALUEOUT> extends
         Map<String, ContentSource> sourceMap = getSourceMap(fastLoad, context);
         getMimetypesMap();
         // construct the ContentWriter
-        return new TransformWriter<VALUEOUT>(conf, sourceMap, fastLoad, am);
+        return new TransformWriter<>(conf, sourceMap, fastLoad, am);
     }
 
     @Override

--- a/mlcp/src/main/java/com/marklogic/contentpump/examples/SimpleSequenceFileCreator.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/examples/SimpleSequenceFileCreator.java
@@ -45,7 +45,7 @@ public class SimpleSequenceFileCreator {
         BufferedReader buffer = new BufferedReader(new FileReader(filePath));
         String line = null;
 
-        SimpleSequenceFileValue<Text> value = new SimpleSequenceFileValue<Text>();
+        SimpleSequenceFileValue<Text> value = new SimpleSequenceFileValue<>();
         try {
             writer = SequenceFile.createWriter(fs, conf, path, key.getClass(),
                 value.getClass());

--- a/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileBytesCreator.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileBytesCreator.java
@@ -24,7 +24,7 @@ public class SimpleSequenceFileBytesCreator {
         Path path = new Path(uri);
         SequenceFile.Writer writer = null;
         SimpleSequenceFileKey key = new SimpleSequenceFileKey();
-        SimpleSequenceFileValue<BytesWritable> value = new SimpleSequenceFileValue<BytesWritable>();
+        SimpleSequenceFileValue<BytesWritable> value = new SimpleSequenceFileValue<>();
         try {
             BytesWritable bw = new BytesWritable();
             byte byteArray[] = {2,3,4};

--- a/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileCompressCreator.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileCompressCreator.java
@@ -33,7 +33,7 @@ public class SimpleSequenceFileCompressCreator {
         BufferedReader buffer = new BufferedReader(new FileReader(filePath));
         String line = null;
 
-        SimpleSequenceFileValue<Text> value = new SimpleSequenceFileValue<Text>();
+        SimpleSequenceFileValue<Text> value = new SimpleSequenceFileValue<>();
         try {
 //            writer = SequenceFile.createWriter(fs, conf, path, key.getClass(),
 //                value.getClass(), CompressionType.BLOCK, new GzipCodec());

--- a/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileLargeBinaryCreator.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/test/SimpleSequenceFileLargeBinaryCreator.java
@@ -27,7 +27,7 @@ public class SimpleSequenceFileLargeBinaryCreator {
         Path path = new Path(uri);
         SequenceFile.Writer writer = null;
         SimpleSequenceFileKey key = new SimpleSequenceFileKey();
-        SimpleSequenceFileValue<BytesWritable> value = new SimpleSequenceFileValue<BytesWritable>();
+        SimpleSequenceFileValue<BytesWritable> value = new SimpleSequenceFileValue<>();
         try {
             BytesWritable bw = new BytesWritable();
             Path file = new Path(binaryfile);

--- a/mlcp/src/main/java/com/marklogic/contentpump/utilities/FileIterator.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/utilities/FileIterator.java
@@ -54,7 +54,7 @@ public class FileIterator implements Iterator<FileSplit> {
         conf = context.getConfiguration();
         fileDirSplits = new LinkedList<FileSplit>();
         PathFilter jobFilter = getInputPathFilter();
-        List<PathFilter> filters = new ArrayList<PathFilter>();
+        List<PathFilter> filters = new ArrayList<>();
         filters.add(FileAndDirectoryInputFormat.hiddenFileFilter);
         if (jobFilter != null) {
             filters.add(jobFilter);
@@ -64,12 +64,12 @@ public class FileIterator implements Iterator<FileSplit> {
 
     public FileIterator(FileSplit inSplit, TaskAttemptContext context) {
         conf = context.getConfiguration();
-        fileDirSplits = new LinkedList<FileSplit>();
-        LinkedList<FileSplit> src = new LinkedList<FileSplit>();
+        fileDirSplits = new LinkedList<>();
+        List<FileSplit> src = new LinkedList<>();
         src.add(inSplit);
         iterator = src.iterator();
         PathFilter jobFilter = getInputPathFilter();
-        List<PathFilter> filters = new ArrayList<PathFilter>();
+        List<PathFilter> filters = new ArrayList<>();
         filters.add(FileAndDirectoryInputFormat.hiddenFileFilter);
         if (jobFilter != null) {
             filters.add(jobFilter);
@@ -116,7 +116,7 @@ public class FileIterator implements Iterator<FileSplit> {
                     FileStatus[] children = fs.listStatus(status.getPath(),
                         inputFilter);
 
-                    List<FileSplit> expdFileSpts = new LinkedList<FileSplit>();
+                    List<FileSplit> expdFileSpts = new LinkedList<>();
                     for (FileStatus stat : children) {
                         FileSplit child = new FileSplit(stat.getPath(), 0,
                             stat.getLen(), null);

--- a/mlcp/src/main/java/com/marklogic/contentpump/utilities/JSONDocBuilder.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/utilities/JSONDocBuilder.java
@@ -105,7 +105,7 @@ public class JSONDocBuilder extends DocBuilder {
             throw new IOException("Fields not defined");
         }
         
-        datatypeMap = new HashMap<String,ColumnDataType>();
+        datatypeMap = new HashMap<>();
         for (String s: fields) {
             datatypeMap.put(s, ColumnDataType.STRING);
         }

--- a/mlcp/src/main/java/com/marklogic/contentpump/utilities/OptionsFileUtil.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/utilities/OptionsFileUtil.java
@@ -51,7 +51,7 @@ public class OptionsFileUtil implements ConfigConstants {
      * @throws Exception
      */
     public static String[] expandArguments(String[] args) throws Exception {
-        List<String> options = new ArrayList<String>();
+        List<String> options = new ArrayList<>();
 
         for (int i = 0; i < args.length; i++) {
             if (args[i].equals(OPTIONS_FILE)) {

--- a/mlcp/src/main/java/com/marklogic/contentpump/utilities/PermissionUtil.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/utilities/PermissionUtil.java
@@ -61,7 +61,7 @@ public class PermissionUtil {
                 ContentCapability capability = getCapbility(perm);
                 if (capability != null) {
                     if (permissions == null) {
-                        permissions = new ArrayList<ContentPermission>();
+                        permissions = new ArrayList<>();
                     }
                     permissions
                         .add(new ContentPermission(capability, roleName));
@@ -74,7 +74,7 @@ public class PermissionUtil {
     
     
     public static List<ContentPermission> getDefaultPermissions(Configuration conf, LinkedMapWritable roleMap) throws IOException {
-        ArrayList<ContentPermission> perms = new ArrayList<ContentPermission>();
+        List<ContentPermission> perms = new ArrayList<>();
         Session session = null;
         ResultSequence result = null;
         ContentSource cs;

--- a/mlcp/src/main/java/com/marklogic/contentpump/utilities/TransformHelper.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/utilities/TransformHelper.java
@@ -39,6 +39,7 @@ import com.marklogic.xcc.ContentCreateOptions;
 import com.marklogic.xcc.ContentPermission;
 import com.marklogic.xcc.DocumentRepairLevel;
 import com.marklogic.xcc.types.ValueType;
+import java.util.Map;
 
 /**
  * Helper class for server-side transform
@@ -117,7 +118,7 @@ public class TransformHelper {
         String functionName, String functionParam, String uri,
         Object value, String type, ContentCreateOptions cOptions)
         throws InterruptedIOException, UnsupportedEncodingException {
-        HashMap<String, String> optionsMap = new HashMap<String, String>();
+        Map<String, String> optionsMap = new HashMap<>();
 
         query.setNewStringVariable("URI", uri);
         ContentType contentType = ContentType.valueOf(type);
@@ -281,7 +282,7 @@ public class TransformHelper {
         String uri, DatabaseDocumentWithMeta doc,
         ContentCreateOptions cOptions) throws InterruptedIOException,
         UnsupportedEncodingException {
-        HashMap<String, String> optionsMap = new HashMap<String, String>();
+        Map<String, String> optionsMap = new HashMap<>();
 
         query.setNewStringVariable("URI", uri);
         ContentType contentType = doc.getContentType();
@@ -380,7 +381,7 @@ public class TransformHelper {
         return query;
     }
 
-    private static String mapToElement(HashMap<String, String> map) {
+    private static String mapToElement(Map<String, String> map) {
         StringBuilder sb = new StringBuilder();
         sb.append(MAP_ELEM_START_TAG);
         Set<String> keys = map.keySet();

--- a/mlcp/src/test/java/com/marklogic/contentpump/Utils.java
+++ b/mlcp/src/test/java/com/marklogic/contentpump/Utils.java
@@ -14,7 +14,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
-import java.util.Properties;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -26,9 +25,10 @@ import com.marklogic.xcc.ResultSequence;
 import com.marklogic.xcc.Session;
 import com.marklogic.xcc.exceptions.RequestException;
 import com.marklogic.xcc.exceptions.XccConfigException;
+import java.util.Map;
 
 public class Utils {
-    private static HashMap<String, ContentSource> csMap = new HashMap<String, ContentSource>();
+    private static Map<String, ContentSource> csMap = new HashMap<>();
     private static Session session;
     public static String newLine = System.getProperty("line.separator");
     public static boolean moduleReady = false;


### PR DESCRIPTION
- Use interfaces for left hand side of assignment, unless specific implementation is needed
- Use diamond operator on right hand side of object assignment to avoid redundant type specification
