### PR TITLE
use Collections.addAll() in place of for loop for array copy

### DIFF
--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ForestDocument.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ForestDocument.java
@@ -35,6 +35,8 @@ import com.marklogic.tree.ExpandedTree;
 import com.marklogic.tree.NodeKind;
 import com.marklogic.xcc.Content;
 import com.marklogic.xcc.ContentCreateOptions;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * A {@link MarkLogicDocument} retrieved from a MarkLogic forest through 
@@ -188,13 +190,9 @@ public abstract class ForestDocument implements MarkLogicDocument {
             } else { // merge
                 HashSet<String> colsSet = new HashSet<String>();
                 if (cols != null) {
-                    for (String col : cols) {
-                        colsSet.add(col);
-                    }
+                    colsSet.addAll(Arrays.asList(cols));
                 }
-                for (String col : collections) {
-                    colsSet.add(col);
-                }
+                Collections.addAll(colsSet, collections);
                 String[] newCols = new String[colsSet.size()];
                 colsSet.toArray(newCols);
                 options.setCollections(newCols);

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueMatch.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValueMatch.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import com.marklogic.mapreduce.functions.ValuesOrWordsFunction.WordsFunction;
+import java.util.Collections;
 
 /**
  * Wrapper class for the <code>cts:value-match</code> lexicon
@@ -71,9 +72,7 @@ public abstract class ValueMatch extends ValueOrWordMatchFunction {
     public static void main(String[] args) {
         ValueMatch matchFunc = new ValueMatchFunction();
         Collection<String> nsbindings = new ArrayList<String>();
-        for (int i = 0; i < args.length; i++) {
-            nsbindings.add(args[i]);
-        }
+        Collections.addAll(nsbindings, args);
         System.out.println(matchFunc.getInputQuery(nsbindings, 1, 1000));
     }
     

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValuesOrWordsFunction.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/functions/ValuesOrWordsFunction.java
@@ -16,6 +16,7 @@
 package com.marklogic.mapreduce.functions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Collection;
 import java.util.Iterator;
 
@@ -102,9 +103,7 @@ public abstract class ValuesOrWordsFunction extends LexiconFunction {
     public static void main(String[] args) {
         Words wordsFunc = new WordsFunction();
         Collection<String> nsbindings = new ArrayList<String>();
-        for (int i = 0; i < args.length; i++) {
-            nsbindings.add(args[i]);
-        }
+        Collections.addAll(nsbindings, args);
         System.out.println(wordsFunc.getInputQuery(nsbindings, 1, 1000));
     }
     

--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
@@ -16,6 +16,7 @@
 package com.marklogic.contentpump;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 


### PR DESCRIPTION
The behavior of this convenience method is identical to that of
c.addAll(Arrays.asList(elements)), but this method is likely to run
significantly faster under most implementations.

https://docs.oracle.com/javase/8/docs/api/java/util/Collections.html#add
All-java.util.Collection-T...-
