### PR TITLE
Fix an occurrence of "the the" in the javadoc pkg desc for the dom pkg

### DIFF
--- a/mapreduce/src/main/java/com/marklogic/dom/package-info.java
+++ b/mapreduce/src/main/java/com/marklogic/dom/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * This package provides W3C DOM based APIs to the
+ * This package provides W3C DOM based APIs to 
  * the internal on-disk representation of documents and their
  * contents in the expanded tree cache of a MarkLogic database
  * forest. 


### PR DESCRIPTION
There's a dup occurrence of "the" in the package description for com.marklogic.com. You can see it in the first sentence on this page:

http://docs.marklogic.com/javadoc/hadoop/com/marklogic/dom/package-summary.html
