### PR TITLE
Bug:51177 - mlcp reports incorrect line number for skipped record whe…

### DIFF
--- a/mlcp/src/main/java/com/marklogic/contentpump/DelimitedTextReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DelimitedTextReader.java
@@ -70,6 +70,7 @@ public class DelimitedTextReader<VALUEIN> extends
     protected boolean compressed;
     protected DocBuilder docBuilder;
     protected Iterator<CSVRecord> parserIterator;
+    private int prevLineNumber = 1;
     
     @Override
     public void close() throws IOException {
@@ -233,6 +234,10 @@ public class DelimitedTextReader<VALUEIN> extends
                 values = getLine();
             }
             int line = (int)parser.getCurrentLineNumber();
+            // If the CSVParser is giving the same line number as previous
+            // because there is no newline char at EOF, manually increase it.
+            if (line == prevLineNumber) line++;
+            prevLineNumber = line;
             if (values.length != fields.length) {
                 setSkipKey(line, 0, 
                         "number of fields does not match number of columns");


### PR DESCRIPTION
Bug:51177 - mlcp reports incorrect line number for skipped record when importing a delimited text file