### PR TITLE
Bug:52904 - mlcp hides the error type when a connection fails

### DIFF
--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
@@ -99,7 +99,9 @@ implements MarkLogicConstants, Configurable {
                 if (ex.getCause() instanceof ServerConnectionException) {
                     LOG.warn("Unable to connect to " + hosts[i]
                             + " to query destination information");
-                    LOG.debug(ex);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(ex);
+                    }
                     continue;
                 } else {
                     throw new IOException(ex);

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicOutputFormat.java
@@ -99,6 +99,7 @@ implements MarkLogicConstants, Configurable {
                 if (ex.getCause() instanceof ServerConnectionException) {
                     LOG.warn("Unable to connect to " + hosts[i]
                             + " to query destination information");
+                    LOG.debug(ex);
                     continue;
                 } else {
                     throw new IOException(ex);

--- a/mlcp/src/main/java/com/marklogic/contentpump/InputType.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/InputType.java
@@ -289,6 +289,7 @@ public enum InputType implements ConfigConstants {
                 } catch (ServerConnectionException e) {
                     LOG.warn("Unable to connect to " + outputHosts[hostIdx]
                             + " to query destination information");
+                    LOG.debug(e);
                     hostIdx++;
                 } catch (XccConfigException e) {
                     throw new IOException(e);

--- a/mlcp/src/main/java/com/marklogic/contentpump/InputType.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/InputType.java
@@ -289,7 +289,9 @@ public enum InputType implements ConfigConstants {
                 } catch (ServerConnectionException e) {
                     LOG.warn("Unable to connect to " + outputHosts[hostIdx]
                             + " to query destination information");
-                    LOG.debug(e);
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(e);
+                    }
                     hostIdx++;
                 } catch (XccConfigException e) {
                     throw new IOException(e);


### PR DESCRIPTION
Log full stack error message at debug level when ServerConnectionException is thrown.