### PR TITLE
Bug:53601 - MLCP user password exposed when DEBUG logging enabled

### DIFF
--- a/mlcp/src/main/java/com/marklogic/contentpump/ContentPump.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/ContentPump.java
@@ -103,10 +103,8 @@ public class ContentPump implements MarkLogicConstants, ConfigConstants {
             boolean isPassword = false;
             for (String arg : optionArgs) {
                 if (isPassword) {
-                    buf.append("...");
-                    buf.append(' ');
+                    arg = "...";
                     isPassword = false;
-                    continue;
                 }
                 if (arg.matches(".*password")) {
                     isPassword = true;

--- a/mlcp/src/main/java/com/marklogic/contentpump/ContentPump.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/ContentPump.java
@@ -99,7 +99,18 @@ public class ContentPump implements MarkLogicConstants, ConfigConstants {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Command: " + command);
             StringBuilder buf = new StringBuilder();
+            // Password masking
+            boolean isPassword = false;
             for (String arg : optionArgs) {
+                if (isPassword) {
+                    buf.append("...");
+                    buf.append(' ');
+                    isPassword = false;
+                    continue;
+                }
+                if (arg.matches(".*password")) {
+                    isPassword = true;
+                }
                 buf.append(arg);
                 buf.append(' ');
             }     


### PR DESCRIPTION
Add password masking when log.debug is turned on.