### PR TITLE
Bug:53741-mlcp export with query filter fails with XDMP-DOCATTRVALCHAR when query has < character

### DIFF
--- a/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -339,6 +339,8 @@ public class DatabaseContentReader extends
             buf.append("(\"unfiltered\",\"score-zero\"))\n");
         } else {
             buf.append("cts:and-query((cts:query(xdmp:unquote('");
+            ctsQuery = ctsQuery.replaceAll("&", "&amp;");
+            ctsQuery = ctsQuery.replaceAll("'", "&apos;");
             buf.append(ctsQuery);
             buf.append("')/*),cts:not-query(cts:document-fragment-query(");
             buf.append("cts:and-query(()))))),");


### PR DESCRIPTION
Add proper escape for ' and & for cts query in mlcp query filter