### PR TITLE
Bug:54421 Bug:54497 - Change default transaction size of mlcp to 1

### DIFF
--- a/mapreduce/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -777,7 +777,7 @@ implements MarkLogicConstants {
             int txnSize = conf.getInt(TXN_SIZE, 0);
             return txnSize <= 0 ? 1 : txnSize;
         } 
-        return 1000 / conf.getInt(BATCH_SIZE, DEFAULT_BATCH_SIZE);
+        return DEFAULT_TXN_SIZE;
     }
     
 }

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicConstants.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicConstants.java
@@ -829,6 +829,10 @@ public interface MarkLogicConstants {
      */
     static final int DEFAULT_BATCH_SIZE = 100;
     /**
+     * Default transaction size.
+     */
+    static final int DEFAULT_TXN_SIZE = 1;
+    /**
      * The config property name (<code>{@value}</code>)
      * which, if set, indicates the number of requests in one transaction. 
      * Optional.

--- a/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicRecordWriter.java
+++ b/mapreduce/src/main/java/com/marklogic/mapreduce/MarkLogicRecordWriter.java
@@ -107,7 +107,7 @@ extends RecordWriter<KEYOUT, VALUEOUT> implements MarkLogicConstants {
     }
        
     public int getTransactionSize(Configuration conf) {
-        return conf.getInt(TXN_SIZE, 1000);
+        return conf.getInt(TXN_SIZE, DEFAULT_TXN_SIZE);
     }
     
 }

--- a/mlcp/src/main/java/com/marklogic/contentpump/Command.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/Command.java
@@ -1941,7 +1941,7 @@ public enum Command implements ConfigConstants {
             .withArgName("number")
             .hasArg()
             .withDescription(
-                    "Number of requests in one transaction (default 10)")
+                    "Number of requests in one transaction (default 1)")
             .create(TRANSACTION_SIZE);
         options.addOption(txnSize);
     }

--- a/mlcp/src/main/java/com/marklogic/contentpump/TransformWriter.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/TransformWriter.java
@@ -139,11 +139,6 @@ public class TransformWriter<VALUEOUT> extends ContentWriter<VALUEOUT> {
         }
     }
     
-    @Override
-    protected boolean needCommit() {
-        return txnSize > 1;
-    }
-    
     private static XdmValue constructTransformOption(Configuration conf,
             String functionParam, String functionNs) {
         HashMap<String, String> transMap = new HashMap<>();


### PR DESCRIPTION
1. Bug 54421: change default transaction size to 1
2. Bug 54497: mlcp failed to import documents with transform module when -transaction_size=1