### PR TITLE
Bug:55027 - Fix security vulnerabilities in libraries used in mlcp

### DIFF
--- a/mapreduce/pom.xml
+++ b/mapreduce/pom.xml
@@ -324,14 +324,9 @@
       <version>1.8.1</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.9.13</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>1.9.13</version>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>info.bliki.wiki</groupId>

--- a/mlcp/pom.xml
+++ b/mlcp/pom.xml
@@ -264,7 +264,7 @@
         <dependency>
           <groupId>xerces</groupId>
           <artifactId>xercesImpl</artifactId>
-          <version>2.11.0</version>
+          <version>2.12.0</version>
         </dependency>
         <dependency>
           <groupId>xpp3</groupId>
@@ -298,12 +298,12 @@
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
-          <version>2.9.0</version>
+          <version>2.11.0</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-core</artifactId>
-          <version>2.9.0</version>
+          <version>2.11.0</version>
         </dependency>
         <dependency>
           <groupId>junit</groupId>
@@ -454,7 +454,7 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.0</version>
     </dependency>
     <dependency>
       <groupId>xpp3</groupId>
@@ -488,12 +488,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.0</version>
+      <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
**mapreduce/pom.xml**
1. Jackson-core-asl and jackson-mapper-asl removed because they have been moved to jackson-core. Jackson-core 2.11.0 added.

**mlcp/pom.xml**
1. xercesImpl from 2.11.0 to 2.12.0
2. jackson-databind from 2.9.0 to 2.11.0
3. jackson-datacore from 2.9.0 to 2.11.0
