### PR TITLE
Add log to report final count of triples

### DIFF
--- a/mlcp/src/main/java/com/marklogic/contentpump/RDFReader.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/RDFReader.java
@@ -168,6 +168,8 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
 
     @Override
     public void close() throws IOException {
+        //report total counts of triples on close
+        LOG.info("Ingested " + ingestedTriples + " triples from " + origFn);
         if(rdfIter!=null) {
             rdfIter.close();
         }


### PR DESCRIPTION
RDFReader reports ingested triples in multiples of 10000 which could be confusing for user. 
The fix is to report on the final count of ingested triples at the end.
Results look like following:

> 20/07/30 11:07:29 INFO contentpump.RDFReader: Ingested 454 triples from file:///.../semantics.rdf
20/07/30 11:07:29 INFO contentpump.RDFReader: Ingested 10000 triples from file:///.../semantics.xml
20/07/30 11:07:30 INFO contentpump.LocalJobRunner:  completed 100%
20/07/30 11:07:31 INFO contentpump.RDFReader: Ingested 17481 triples from file:///.../semantics.xml
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: com.marklogic.mapreduce.MarkLogicCounter: 
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: INPUT_RECORDS: 180
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: OUTPUT_RECORDS: 180
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: OUTPUT_RECORDS_COMMITTED: 180
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: OUTPUT_RECORDS_FAILED: 0
20/07/30 11:07:31 INFO contentpump.LocalJobRunner: Total execution time: 2 sec