### PR TITLE
Bug:55117 pass metadata to transform function

### DIFF
--- a/mlcp/src/main/java/com/marklogic/contentpump/TransformWriter.java
+++ b/mlcp/src/main/java/com/marklogic/contentpump/TransformWriter.java
@@ -473,6 +473,12 @@ public class TransformWriter<VALUEOUT> extends ContentWriter<VALUEOUT> {
             optionsMap.put("properties", properties);
         }
 
+        Map<String, String> meta = options.getMetadata();
+        if (meta != null && meta instanceof HashMap) {
+            HashMap<String, String> hMeta = (HashMap<String, String>) meta;
+            optionsMap.put("metadata", mapToNode(hMeta).toString());
+        }
+
         if (effectiveVersion < ConfigConstants.BATCH_MIN_VERSION) {
             String optionElem = mapToElement(optionsMap);
             optionsVals[id][counts[id]] = 


### PR DESCRIPTION
Pass metadata into insert-options fields in TransformWriter. Server could pick up the metadata from the insert-options