### PR TITLE
Fix bugs in TransformWriter, improve mlcp logging and increase retry time limit

### DIFF
--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -202,7 +202,7 @@ implements MarkLogicConstants {
 
     protected final int MINSLEEPTIME = 500;
 
-    protected final int MAXSLEEPTIME = 30000;
+    protected final int MAXSLEEPTIME = 120000;
 
     
     public ContentWriter(Configuration conf, 
@@ -892,7 +892,7 @@ implements MarkLogicConstants {
     protected int sleep(int sleepTime) {
         try {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Sleeping..." + "sleepTime=" + sleepTime);
+                LOG.debug("Sleeping..." + "sleepTime=" + sleepTime + "ms");
             }
             InternalUtilities.sleep(sleepTime);
         } catch (Exception e) {}


### PR DESCRIPTION
1. Fix bugs in TransformWriter based on Silvano's testing.
2. Improve mlcp logging.
3. Increase retry time limit from 30s to 120s.