### PR TITLE
Bug:55477 Map mlcp error code for XDMP-MODNOTFOUND from 500 to 404

### DIFF
--- a/src/main/java/com/marklogic/contentpump/TransformWriter.java
+++ b/src/main/java/com/marklogic/contentpump/TransformWriter.java
@@ -595,8 +595,8 @@ public class TransformWriter<VALUEOUT> extends ContentWriter<VALUEOUT> {
             } else if (e instanceof RequestServerException) {
                 LOG.warn(getFormattedBatchId() + "RequestServerException:" + e.getMessage());
             } else {
-                LOG.warn(getFormattedBatchId() + "Exception:" + e.getMessage());
-                if (e.getMessage().contains("404")) {
+                LOG.warn(getFormattedBatchId() + "Exception: " + e.getMessage());
+                if (e.getMessage().contains("Module Not Found")) {
                     retryable = false;
                 }
             }

--- a/src/main/java/com/marklogic/contentpump/TransformWriter.java
+++ b/src/main/java/com/marklogic/contentpump/TransformWriter.java
@@ -596,6 +596,9 @@ public class TransformWriter<VALUEOUT> extends ContentWriter<VALUEOUT> {
                 LOG.warn(getFormattedBatchId() + "RequestServerException:" + e.getMessage());
             } else {
                 LOG.warn(getFormattedBatchId() + "Exception:" + e.getMessage());
+                if (e.getMessage().contains("404")) {
+                    retryable = false;
+                }
             }
             LOG.warn(getFormattedBatchId() + "Failed during inserting");
             if (needCommit) {

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -548,6 +548,9 @@ implements MarkLogicConstants {
                         "RequestServerException: " + e.getMessage());
                 } else {
                     LOG.warn(getFormattedBatchId() + "Exception: " + e.getMessage());
+                    if (e.getMessage().contains("404")) {
+                        retryable = false;
+                    }
                 }
                 LOG.warn(getFormattedBatchId() + "Failed during inserting");
                 // necessary to roll back in certain scenarios.

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -548,7 +548,7 @@ implements MarkLogicConstants {
                         "RequestServerException: " + e.getMessage());
                 } else {
                     LOG.warn(getFormattedBatchId() + "Exception: " + e.getMessage());
-                    if (e.getMessage().contains("404")) {
+                    if (e.getMessage().contains("Module Not Found")) {
                         retryable = false;
                     }
                 }


### PR DESCRIPTION
1. Map error code for XDMP-MODNOTFOUND from 500 to 404.
2. Stop batch retrying for all 404 errors