### PR TITLE
Correct javadoc parameter annotations

### DIFF
--- a/src/main/java/com/marklogic/contentpump/Command.java
+++ b/src/main/java/com/marklogic/contentpump/Command.java
@@ -1869,8 +1869,7 @@ public enum Command implements ConfigConstants {
      * 
      * @param conf
      *            Hadoop configuration
-     * @param options
-     *            options
+     * @param cmdline command line options
      * @return a Hadoop job
      * @throws Exception
      */
@@ -1895,7 +1894,7 @@ public enum Command implements ConfigConstants {
      * 
      * @param job the Hadoop job 
      * @param conf Hadoop configuration
-     * @param CommandLine command line
+     * @param cmdline command line options
      */
     public abstract void setMapperClass(Job job, Configuration conf, 
     		CommandLine cmdline);

--- a/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
+++ b/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
@@ -107,10 +107,10 @@ implements ConfigConstants {
 
     /**
      * Set the result as DocumentURI key.
-     * 
-     * @param uri Source string of document URI.
+     *
      * @param line Line number in the source if applicable; -1 otherwise.
      * @param col Column number in the source if applicable; -1 otherwise.
+     * @param reason
      * 
      * @return true if key indicates the record is to be skipped; false 
      * otherwise.

--- a/src/main/java/com/marklogic/contentpump/InputType.java
+++ b/src/main/java/com/marklogic/contentpump/InputType.java
@@ -399,7 +399,8 @@ public enum InputType implements ConfigConstants {
     /**
      * Get InputFormat class based on content type.
      * 
-     * @param contentType content type
+     * @param cmdline command line options
+     * @param conf configuration
      * @return InputFormat class
      */
     public abstract Class<? extends FileInputFormat> getInputFormatClass(
@@ -408,7 +409,8 @@ public enum InputType implements ConfigConstants {
     /**
      * Get Mapper class based on content type.
      * 
-     * @param contentType content type
+     * @param cmdline command line options
+     * @param conf configuration
      * @return Mapper class
      */
     public <K1, V1, K2, V2> Class<? extends BaseMapper<K1, V1, K2, V2>> 

--- a/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
+++ b/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
@@ -141,19 +141,12 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
 
     /**
      * Set the application's mapper class.
-     * 
-     * @param <K1>
-     *            the map input key type
-     * @param <V1>
-     *            the map input value type
-     * @param <K2>
-     *            the map output key type
-     * @param <V2>
-     *            the map output value type
-     * @param job
-     *            the job to modify
-     * @param internalMapperClass
-     *            the class to use as the mapper
+     * @param conf
+     * @param internalMapperClass the class to use as the mapper
+     * @param <K1> the map input key type
+     * @param <V1> the map input value type
+     * @param <K2> the map output key type
+     * @param <V2> the map output value type
      */
     public static <K1, V1, K2, V2> void setMapperClass(Configuration conf,
         Class<? extends BaseMapper<?, ?, ?, ?>> internalMapperClass) {

--- a/src/main/java/com/marklogic/contentpump/utilities/AuditUtil.java
+++ b/src/main/java/com/marklogic/contentpump/utilities/AuditUtil.java
@@ -60,7 +60,8 @@ public class AuditUtil {
     }
     
     /**
-     * @param job
+     * @param conf
+     * @param jobName
      * @param counters
      * @throws IOException
      */

--- a/src/main/java/com/marklogic/mapreduce/ForestReader.java
+++ b/src/main/java/com/marklogic/mapreduce/ForestReader.java
@@ -215,7 +215,7 @@ implements MarkLogicConstants {
      * Set the result as 
      * DocumentURI key.
      * 
-     * @param uri Source string of document URI.
+     * @param sub Source string of document URI.
      * @param line Line number in the source if applicable; -1 otherwise.
      * @param col Column number in the source if applicable; -1 otherwise.
      * @param reason Reason for skipping.

--- a/src/main/java/com/marklogic/mapreduce/utilities/RestrictedHostsUtil.java
+++ b/src/main/java/com/marklogic/mapreduce/utilities/RestrictedHostsUtil.java
@@ -41,7 +41,7 @@ public class RestrictedHostsUtil {
     
     /**
      * 
-     * @param hosts
+     * @param restrictHosts
      */
     public RestrictedHostsUtil(String[] restrictHosts) {
         this.restrictHosts = Arrays.asList(restrictHosts);


### PR DESCRIPTION
Various fixes for incorrect `@param` annotations.

This one is incorrect, as JSONDocument does not have a `getDocument()` method, but not sure what it should reference instead:
https://github.com/marklogic/marklogic-contentpump/blob/develop/src/main/java/com/marklogic/mapreduce/JSONDocument.java#L53