### PR TITLE
Fix #255 incorrect dependency in CustomQuery.java (Java 11)

### DIFF
--- a/src/main/java/com/marklogic/mapreduce/test/CustomQuery.java
+++ b/src/main/java/com/marklogic/mapreduce/test/CustomQuery.java
@@ -17,7 +17,7 @@ package com.marklogic.mapreduce.test;
 
 import java.io.IOException;
 
-import javax.xml.soap.Node;
+import org.w3c.dom.Node;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;


### PR DESCRIPTION
There is one instance, only in the file modified here, of importing the class javax.xml.soap.Node. This is the wrong dependency, and additionally no longer compatible with Java 11+ where JAX-WS has been fully removed.

Tested against Java 8 with all unit tests passing, and Java 11 now able to compile, and this particular test passing.