### PR TITLE
MLE-10994:Update maven javadoc plugin in mlcp to mitigate security vu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10.3</version>
+        <version>3.6.3</version>
         <configuration>
           <source>8</source>
           <header>${productNameShort} ${versionString}</header>
@@ -243,6 +243,11 @@
           <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
           <reportOutputDirectory>${project.reporting.outputDirectory}/javadoc</reportOutputDirectory>
           <sourcePath>src</sourcePath>
+          <quiet>true</quiet>
+          <failOnError>false</failOnError>
+          <doclint>none</doclint>
+          <additionalparam>-Xdoclint:none</additionalparam>
+          <noindex>true</noindex>
           <bottom><![CDATA[
             <i>${javadocCopyrightMessage}</i>
             <p>Complete online documentation for MarkLogic Server,

--- a/src/main/java/com/marklogic/contentpump/ArchiveWriter.java
+++ b/src/main/java/com/marklogic/contentpump/ArchiveWriter.java
@@ -34,7 +34,7 @@ import com.marklogic.mapreduce.MarkLogicDocument;
 import com.marklogic.mapreduce.utilities.URIUtil;
 
 /**
- * RecordWriter that writes <DocumentURI, MarkLogicDocument> to zip files.
+ * RecordWriter that writes &lt;DocumentURI, MarkLogicDocument&gt; to zip files.
  * 
  * @author jchen
  */

--- a/src/main/java/com/marklogic/contentpump/Command.java
+++ b/src/main/java/com/marklogic/contentpump/Command.java
@@ -1993,7 +1993,6 @@ public enum Command implements ConfigConstants {
      *            Hadoop configuration
      * @param cmdline command line options
      * @return a Hadoop job
-     * @throws Exception
      */
     public abstract Job createJob(Configuration conf, CommandLine cmdline)
                     throws IOException;

--- a/src/main/java/com/marklogic/contentpump/CompressedStreamingReader.java
+++ b/src/main/java/com/marklogic/contentpump/CompressedStreamingReader.java
@@ -19,7 +19,7 @@ import com.marklogic.mapreduce.StreamLocator;
 
 /**
  * Reader for compressed documents from file systems and produce
- * <DocumentURI, Path> pairs. 
+ * &lt;DocumentURI, Path&gt; pairs. 
  * 
  * @author jchen
  */

--- a/src/main/java/com/marklogic/contentpump/ConfigConstants.java
+++ b/src/main/java/com/marklogic/contentpump/ConfigConstants.java
@@ -247,7 +247,7 @@ public interface ConfigConstants {
             "mapreduce.marklogic.input.modulesroot";
 
     /**
-     * <Role-name,Role-id> map for internal use
+     * &lt;Role-name,Role-id&gt; map for internal use
      */
     static final String CONF_ROLE_MAP = "mapreduce.marklogic.output.rolemap";
     

--- a/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -57,7 +57,7 @@ import com.marklogic.xcc.types.XdmItem;
 
 /**
  * A MarkLogicRecordReader that fetches data from MarkLogic server and generates 
- * <DocumentURI, MarkLogicDocument> key value pairs.
+ * &lt;DocumentURI, MarkLogicDocument&gt; key value pairs.
  * 
  * @author ali
  * 

--- a/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
+++ b/src/main/java/com/marklogic/contentpump/ImportRecordReader.java
@@ -112,7 +112,6 @@ implements ConfigConstants {
      * @param col Column number in the source if applicable; -1 otherwise.
      * @param reason
      * 
-     * @return true if key indicates the record is to be skipped; false 
      * otherwise.
      */
     protected void setSkipKey(int line, int col, String reason) {

--- a/src/main/java/com/marklogic/contentpump/SingleDocumentWriter.java
+++ b/src/main/java/com/marklogic/contentpump/SingleDocumentWriter.java
@@ -42,7 +42,7 @@ import com.marklogic.mapreduce.MarkLogicDocument;
 import com.marklogic.mapreduce.utilities.URIUtil;
 
 /**
- * RecordWriter for <DocumentURI, MarkLogicDocument> creating a single
+ * RecordWriter for &lt;DocumentURI, MarkLogicDocument&gt; creating a single
  * file.
  * 
  * @author jchen

--- a/src/main/java/com/marklogic/dom/DocumentImpl.java
+++ b/src/main/java/com/marklogic/dom/DocumentImpl.java
@@ -85,10 +85,10 @@ public class DocumentImpl extends NodeImpl implements Document {
      * <p>
      * Text documents in MarkLogic cannot be cloned.
      * UnsupportedOperationException will be thrown if cloneNode is call on text
-     * document. </>
+     * document.
      * <p>
      * DocumentType node will not be cloned as it is not part of the Expanded
-     * Tree.</>
+     * Tree.
      * 
      * 
      */

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -150,7 +150,7 @@ implements MarkLogicConstants {
     
     protected boolean countBased;
     
-    /** role-id -> role-name mapping **/
+    /** role-id -&gt; role-name mapping **/
     protected LinkedMapWritable roleMap;
     
     protected HashMap<String,ContentPermission[]> permsMap;

--- a/src/main/java/com/marklogic/mapreduce/ForestReader.java
+++ b/src/main/java/com/marklogic/mapreduce/ForestReader.java
@@ -220,7 +220,6 @@ implements MarkLogicConstants {
      * @param col Column number in the source if applicable; -1 otherwise.
      * @param reason Reason for skipping.
      * 
-     * @return true if key indicates the record is to be skipped; false 
      * otherwise.
      */
     protected void setSkipKey(String sub, int line, int col, String reason) {

--- a/src/main/java/com/marklogic/mapreduce/JSONDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/JSONDocument.java
@@ -37,12 +37,6 @@ import com.marklogic.xcc.ContentFactory;
  * representation of a document as stored in the expanded tree
  * cache of a forest on disk.
  * 
- * <p>
- * You cannot use this class to modify a document. However, you
- * can create a modifiable copy of the underlying document
- * using {@link com.marklogic.dom.DocumentImpl} on the 
- * document returned by {@link #getDocument}.
- * </p>
  * 
  * @author jchen
  *

--- a/src/main/java/com/marklogic/mapreduce/MarkLogicConstants.java
+++ b/src/main/java/com/marklogic/mapreduce/MarkLogicConstants.java
@@ -241,7 +241,7 @@ public interface MarkLogicConstants {
      *  to generate input splits. This property is required (and only 
      *  usable) in <code>advanced</code> mode; see the
      *  {@link #INPUT_MODE input.mode} property for details.
-     * </p>
+     * 
      * <p>
      *  The split query must return a sequence of (forest id, record 
      *  count, hostname) tuples. The host name and forest id identify
@@ -327,7 +327,7 @@ public interface MarkLogicConstants {
      *  records from MarkLogic Server. This property is required
      *  when <code>advanced</code> is specified in the
      *  {@link #INPUT_MODE input.mode} property.
-     * </p>
+     * 
      * 
      * <p>
      *  The value of this property must be a fully formed query,
@@ -345,7 +345,7 @@ public interface MarkLogicConstants {
      *  The config property name (<code>{@value}</code>)
      *  which, if set, specifies data retrieval from MarkLogic Server at the 
      *  specified timestamp. 
-     * </p>
+     * 
      */
     static final String INPUT_QUERY_TIMESTAMP = 
         "mapreduce.marklogic.input.querytimestamp";

--- a/src/main/java/com/marklogic/mapreduce/MarkLogicRecordReader.java
+++ b/src/main/java/com/marklogic/mapreduce/MarkLogicRecordReader.java
@@ -44,11 +44,12 @@ import com.marklogic.xcc.exceptions.RequestException;
 import com.marklogic.xcc.exceptions.XccConfigException;
 /**
  * A RecordReader that fetches data from MarkLogic server and generates 
- * <K, V> key value pairs.
+ * &lt;K, V&gt; key value pairs.
  * 
  * @author jchen
  * 
- * @param <KEYIN, VALUEIN>
+ * @param <KEYIN>
+ * @param <VALUEIN>
  */
 public abstract class MarkLogicRecordReader<KEYIN, VALUEIN> 
 extends RecordReader<KEYIN, VALUEIN>

--- a/src/main/java/com/marklogic/mapreduce/NodeOpType.java
+++ b/src/main/java/com/marklogic/mapreduce/NodeOpType.java
@@ -32,14 +32,14 @@ package com.marklogic.mapreduce;
  * </p>
  * <p>
  *  For more information, see the following built-in functions in the
- *  <em>XQuery & XSLT API Reference</em>:
+ *  <em>XQuery &amp; XSLT API Reference</em>:
  *  <ul>
  *   <li>xdmp:node-insert-before</li>
  *   <li>xdmp:node-insert-after</li>
  *   <li>xdmp:node-insert-child</li>
  *   <li>xdmp:node-insert-replace</li>
  *  </ul>
- * </p>
+ * 
  * 
  * @author jchen
  */

--- a/src/main/java/com/marklogic/mapreduce/PropertyOpType.java
+++ b/src/main/java/com/marklogic/mapreduce/PropertyOpType.java
@@ -33,12 +33,11 @@ import org.apache.hadoop.conf.Configuration;
  * </p>
  * <p>
  *  For more information, see the following built-in functions in the
- *  <em>XQuery & XSLT API Reference</em>:
+ *  <em>XQuery &amp; XSLT API Reference</em>:
  *  <ul>
  *   <li>xdmp:document-set-property</li>
  *   <li>xdmp:document-add-properties</li>
  *  </ul>
- * </p>
  * 
  * @author jchen
  */


### PR DESCRIPTION
1. Upgrade Maven Javadoc plugin from 2.10.3 to 3.6.3
2. Exclude jquery from maven-javadoc-plugin
3. Fixed malformed html Javadoc by following solutions:
      1.  Delete expected end tag </p>
      2. Use &lt; for < and &gt; for >
      3. The ampersand (&) should be written &amp;
      4. Void methods should have no @return tag
      5. Deleted the @throws
      6. Delete unused reference