### PR TITLE
MLE-15379: Fix Security Vulnerabilities with MEDIUM severity in develop-11.3 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.10.0</version>
         <configuration>
           <source>8</source>
           <header>${productNameShort} ${versionString}</header>
@@ -334,6 +334,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -388,6 +392,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -528,6 +536,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -599,6 +611,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -637,6 +653,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -685,6 +705,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -731,6 +755,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -779,6 +807,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -813,6 +845,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -893,6 +929,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -931,6 +971,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1324,6 +1368,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1347,6 +1395,10 @@
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1369,6 +1421,10 @@
         <exclusion>
           <groupId>commons-collections</groupId>
           <artifactId>commons-collections</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
According to Last’s week palamida scan, there are still two vulnerable libs in MLCP develop-11:
1. netty-codec-http
2. commons-collections 3.2.1

**After checking the local Maven Central**:
1. netty-codec-http in /users/ml/yjiang/.m2/repository/io/netty
2. commons-collections/3.2.1. ~/.m2/repository/commons-collections/commons-collections/

**Analysis**:
1. We should remove the netty-codec-http lib transitive dependencies (those brought in through other dependencies) from the project. 
2. commons-collections/3.2.1 was download in maven-javadoc-plugin:3.6.3:javadoc 
![image](https://github.com/user-attachments/assets/b84dc48a-9bad-4e87-bb39-df6e5dfa3cdc)

**Solution**:
1. Upgrade javadoc maven-javadoc-plugin from 3.6.3 to 3.10.0
2. Exclude netty-codec-http from all hadoop project
![image](https://github.com/user-attachments/assets/aa429284-11c2-47a3-9300-4509eca38908)
![image](https://github.com/user-attachments/assets/889d0184-17a7-4a2d-ba62-046fbda2c869)

**Tests**:

mvn test

```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 14.116 sec - in com.marklogic.contentpump.TestReturnCode
Running com.marklogic.dom.NodeImplTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in com.marklogic.dom.NodeImplTest

```


make tests tname=06mlcp pkg=/tmp/MarkLogic-11.4.20240917-rhel.x86_64.rpm mlcp_pkg=/tmp/mlcp-11.4-bin.zip xcc_pkg=/tmp/MarkXCC.Java-11.4-20240917.zip

```
06mlcp test suite
Total test sets: 142  PASS: 134  FAIL: 8
Following tests have failed:
mlcp-metadata-setup.xml
bug17845.xml
rebal-bucket-mlcp-mixed.xml
mlcp-basic-8000.xml
mlcp-aggregates-8000.xml
mlcp-export-query-filter.xml
mlcp-ssl-protocal-tls-49273.xml
mlcp-group-host-count.xml
```

**These unit tests failed because:**

1. QA input files missing or internal QA framework breaks
2. Inappropriate environment set up -- need to run in cluste 
3. I re-run some of them as unit test and passed:
- Test mlcp-metadata-setup.xml: Passed
- Test bug17845.xml: Passed