### PR TITLE
MLE-17188: develop-11.3 fix protobuf-java 3.21.12 - 8.7 HIGH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1455,8 +1455,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop.thirdparty</groupId>
-      <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
-      <version>1.2.0</version>
+      <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
+      <version>1.3.0</version>
       <exclusions>
         <exclusion>
           <groupId>dnsjava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -338,6 +338,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -396,6 +400,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -540,6 +548,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -615,6 +627,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -657,6 +673,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -709,6 +729,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -759,6 +783,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -811,6 +839,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -849,6 +881,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -933,6 +969,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -975,6 +1015,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1372,6 +1416,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1399,6 +1447,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1425,6 +1477,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-codec-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/assemble/bindist.xml
+++ b/src/assemble/bindist.xml
@@ -129,7 +129,7 @@
         <include>org.apache.hadoop:hadoop-hdfs-client:jar:*</include>
         <include>org.apache.hadoop:hadoop-client:jar:*</include>
         <include>org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:*</include>
-        <include>org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21:jar:*</include>
+        <include>org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_25:jar:*</include>
         <include>commons-logging:commons-logging:jar:*</include>
         <include>xml-apis:ml-apis:jar:*</include>
         <include>jakarta.xml.soap:jakarta.xml.soap-api:jar:*</include>


### PR DESCRIPTION
1. Upgrade the hadoop-shaded-protobuf from 3.21 to 3.25
2. Exculde hadoop-shaded-protobuf from Hadoop project to prevent downloading it from Maven central

Test results:
1. mvn test
```
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 13.828 sec - in com.marklogic.contentpump.TestReturnCode
Running com.marklogic.contentpump.CommandTest
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.mockito.cglib.core.ReflectUtils$2 (file:/users/ml/yjiang/.m2/repository/org/mockito/mockito-all/1.10.19/mockito-all-1.10.19.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of org.mockito.cglib.core.ReflectUtils$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.151 sec - in com.marklogic.contentpump.CommandTest
Running com.marklogic.dom.NodeImplTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in com.marklogic.dom.NodeImplTest

Results :

Tests run: 211, Failures: 0, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  14:37 min
[INFO] Finished at: 2024-10-03T16:09:24-07:00
[INFO] ------------------------------------------------------------------------
```

2. make tests tname=06mlcp pkg=/tmp/MarkLogic-11.4.20240917-rhel.x86_64.rpm mlcp_pkg=/tmp/mlcp-11.4-bin.zip  xcc_pkg=/tmp/MarkXCC.Java-11.4-20241003.zip
```
Total test sets: 142  PASS: 135  FAIL: 7
http://localhost:8050/change-xdbc-db.xqy?db=Documents&xdbcName=QAxdbcServer
http://localhost:8050/change-xdbc-db.xqy?db=Documents&xdbcName=QAxdbcServer OK
Last query did not returned anything, but proceeding
clearing database
****start reset****
http://localhost:8050/assign-forests.xqy?db=Documents&forest=Documents
http://localhost:8050/assign-forests.xqy?db=Documents&forest=Documents OK
http://localhost:8050/remove-userroles.xqy
http://localhost:8050/remove-userroles.xqy OK
http://localhost:8050/change-http-db.xqy?db=Documents&httpName=qa
http://localhost:8050/change-http-db.xqy?db=Documents&httpName=qa OK
http://localhost:8050/change-app-server.xqy?type=xdbc&srname=QAxdbcServer&modules=&library=/space/code/qanew/app
http://localhost:8050/change-app-server.xqy?type=xdbc&srname=QAxdbcServer&modules=&library=/space/code/qanew/app OK
****finish reset****
diffDestDirOnRoot=none
suite 06mlcp End time: 2024/10/04 06:16:26
Waiting  for all Suites to be done!! Job size:0
###########################################
Following test suites are executed: 06mlcp
Total number of Suite(s) Executed 2
Total number of Suite(s) failed 0
Time taken to run the tests: 1hr 17min
Check out /tmp/logs.develop.2410040458 directory for detail logs
###########################################
```
Some tests failures are expected due to environment setup 

3. Local ~/.m2 repo
![image](https://github.com/user-attachments/assets/b67591ac-2125-4595-add3-808c81811f17)
hadoop-shaded-protobuf_3_21 does not exit anymore 

4. deliverable  mlcp-11.4-bin.zip file 
![image](https://github.com/user-attachments/assets/776c97a8-0a7d-4f25-a012-f24faf8139d6)
