### PR TITLE
MLE-17253: (CVE) MLCP - Apache Avro 1.11.3 - 7.3 HIGH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1487,7 +1487,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.3</version>
+      <version>1.11.4</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
 1. Upgrade org.apache.avro from 1.11.3 to 1.11.4

Right now it only downloads the 1.11.4 version after fixing 
![image](https://github.com/user-attachments/assets/51e18403-b528-4c32-be79-0a28f48f6f09)

Start testing, I will upload the test result before getting approval for this request.