### PR TITLE
MLE-17858:(CVE) MLCP - com.thoughtworks.xstream:xstream - 7.5 HIGH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1224,7 +1224,7 @@
     <dependency>
       <groupId>com.thoughtworks.xstream</groupId>
       <artifactId>xstream</artifactId>
-      <version>1.4.20</version>
+      <version>1.4.21</version>
       <exclusions>
         <exclusion>
           <groupId>io.github.x-stream</groupId>


### PR DESCRIPTION
1. Upgrade xstream from 1.4.20 to 1.4.21

Test results:
1. Check local maven repo:
![image](https://github.com/user-attachments/assets/83814810-59ac-4866-83d2-c8c1ceb85571)
only the lastest version 1.4.21 has been used

2. mvn test 
![image](https://github.com/user-attachments/assets/170af5f0-643c-47cc-82a1-a9cdd58af4d5)
