### PR TITLE
MLE-18305: (CVE) MLCP - org.apache.jena:jena-shaded-guava:4.8.0 - 7.1 HIGH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1141,11 +1141,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-shaded-guava</artifactId>
-      <version>4.8.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.andrewoma.dexx</groupId>
       <artifactId>collection</artifactId>
       <version>0.7</version>


### PR DESCRIPTION
Summary: 
MLCP depends directly on  jena-shaded-guava:4.8.0, which contains a shaded version(repackage the dependencies under a new namespace) of Google’s guava library. Since MLCP only uses guava during the test stage, it makes sense to delete jena-shaded-guava:4.8.0 dependency.

Test result:
1. mvn test
![image](https://github.com/user-attachments/assets/558cfe08-b5f4-46e5-b670-b9ccee0b5fe2)

2. regression test
![image](https://github.com/user-attachments/assets/f85978ef-5244-4236-b779-e2231861e646)
Some regression test failures are expected due to local environment setup 