### PR TITLE
MLE-19096: hadoop-shaded-protobuf_3_25:1.3.0 - 8.5 High

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1489,41 +1489,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop.thirdparty</groupId>
-      <artifactId>hadoop-shaded-protobuf_3_25</artifactId>
-      <version>1.3.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>dnsjava</groupId>
-          <artifactId>dnsjava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-codec-http</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.hadoop.thirdparty</groupId>
-          <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
-        </exclusion>
-         <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.11.4</version>


### PR DESCRIPTION
MLCP directly depends  on hadoop-shaded-protobuf_3_25  which contains a shaded version(repackage the dependencies under a new namespace) of Google’s protobuf library 3.25.3.  Since there is no usage of this library through MLCP and this vulnerability is not exploitable through mlcp,  we remove hadoop-shaded-protobuf from compile classpath

Test results:
1. mvn test
![image](https://github.com/user-attachments/assets/57932062-b18e-4b0a-af3e-4a6214f8ee55)

2. Regression test
![image](https://github.com/user-attachments/assets/0bb41548-f636-4ae7-a636-509f0829c0f9)
Some regression test failures are expected due to local environment setup