### PR TITLE
MLE-18362: (CVE) MLCP - netty-common 4.1.100.Final - 5.5 MEDIUM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -346,6 +346,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -412,6 +416,10 @@
          <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -540,6 +548,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -619,6 +631,10 @@
           <groupId>org.apache.hadoop.thirdparty</groupId>
           <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -669,6 +685,10 @@
          <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -729,6 +749,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -788,6 +812,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -843,6 +871,10 @@
           <groupId>org.apache.hadoop.thirdparty</groupId>
           <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -885,6 +917,10 @@
         <exclusion>
           <groupId>org.apache.hadoop.thirdparty</groupId>
           <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -977,6 +1013,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1027,6 +1067,10 @@
          <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1427,6 +1471,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1462,6 +1510,10 @@
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion> 
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Solution:
1. Add exclusion for all Hadoop project

Test:
1. Local .m2 check
No netty-common 4.1.100 download to local building environment (~/.m2) 
No netty-common 4.1.100 was found in dependency tree

2. mvn test 
![image](https://github.com/user-attachments/assets/a78cfebe-11da-45e5-aa94-7a0a6fc3c28e)

3. Regression test
![image](https://github.com/user-attachments/assets/7a1803fd-edf5-46e6-b068-1bfaccba233a)

Some test failures are expected due to the local environment setup
