### PR TITLE
MLE-17594: (CVE) MLCP - jetty-http 9.4.53.v20231009

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,6 +347,10 @@
           <artifactId>protobuf-java</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
@@ -420,6 +424,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -576,6 +584,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -659,6 +671,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -713,6 +729,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -772,6 +792,10 @@
          <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
         </exclusion>
         <exclusion>
           <groupId>io.netty</groupId>
@@ -840,6 +864,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -899,6 +927,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -945,6 +977,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1041,6 +1077,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1095,6 +1135,10 @@
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -1499,6 +1543,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1538,6 +1586,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-common</artifactId>
         </exclusion> 
+        <exclusion>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
Solution:
1. Add exclusion for all Hadoop project

Test:
1. Local .m2 check
No jetty-http 9.4.53 download to local building environment (~/.m2)
No jetty-http 9.4.53was found in dependency tree

2. mvn test 
![image](https://github.com/user-attachments/assets/393bd4c0-90b6-4fc4-a26e-c3dd06102fcc)

3. Regression test
![image](https://github.com/user-attachments/assets/78b10867-91fa-4013-9a48-5ac3a937ce55)
Some test failures are expected due to local environment set