### PR TITLE
MLE-21183:Change MLCloudRequestException to PDCloudRequestException

### DIFF
--- a/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -22,7 +22,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import com.marklogic.xcc.exceptions.MLCloudRequestException;
+import com.marklogic.xcc.exceptions.PDCloudRequestException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -289,9 +289,9 @@ public class DatabaseContentReader extends
             throw new IOException(e);
         } catch (Exception e) {
             boolean isRetryable = true;
-            if (e instanceof MLCloudRequestException){
-                isRetryable = ((MLCloudRequestException)e).isRetryable();
-                LOG.error("MLCloudRequestException:" + e.getMessage());
+            if (e instanceof PDCloudRequestException){
+                isRetryable = ((PDCloudRequestException)e).isRetryable();
+                LOG.error("PDCloudRequestException:" + e.getMessage());
             } else {
                 LOG.error("Exception:" + e.getMessage());
             }

--- a/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
@@ -20,7 +20,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Vector;
 
-import com.marklogic.xcc.exceptions.MLCloudRequestException;
+import com.marklogic.xcc.exceptions.PDCloudRequestException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -304,10 +304,10 @@ public class DatabaseContentWriter<VALUE> extends
                     } catch (Exception e) {
                         boolean isRetryable = true;
                         LOG.warn("Failed committing transaction.");
-                        if (e instanceof MLCloudRequestException){
-                            isRetryable = ((MLCloudRequestException)e).isRetryable();
+                        if (e instanceof PDCloudRequestException){
+                            isRetryable = ((PDCloudRequestException)e).isRetryable();
                             LOG.warn(getFormattedBatchId() +
-                                "MLCloudRequestException:" + e.getMessage());
+                                "PDCloudRequestException:" + e.getMessage());
                         } else {
                             LOG.warn(getFormattedBatchId() +
                                 "Exception:" + e.getMessage());

--- a/src/main/java/com/marklogic/contentpump/DatabaseTransformWriter.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseTransformWriter.java
@@ -18,7 +18,7 @@ package com.marklogic.contentpump;
 import java.io.IOException;
 import java.util.Map;
 
-import com.marklogic.xcc.exceptions.MLCloudRequestException;
+import com.marklogic.xcc.exceptions.PDCloudRequestException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -120,10 +120,10 @@ public class DatabaseTransformWriter<VALUE> extends
                         } catch (Exception e) {
                             boolean isRetryable = true;
                             LOG.warn("Failed committing transaction.");
-                            if (e instanceof MLCloudRequestException){
-                                isRetryable = ((MLCloudRequestException)e).isRetryable();
+                            if (e instanceof PDCloudRequestException){
+                                isRetryable = ((PDCloudRequestException)e).isRetryable();
                                 LOG.warn(getFormattedBatchId() +
-                                    "MLCloudRequestException:" + e.getMessage());
+                                    "PDCloudRequestException:" + e.getMessage());
                             } else {
                                 LOG.warn(getFormattedBatchId() +
                                     "Exception:" + e.getMessage());

--- a/src/main/java/com/marklogic/contentpump/ThreadManager.java
+++ b/src/main/java/com/marklogic/contentpump/ThreadManager.java
@@ -16,7 +16,7 @@
 package com.marklogic.contentpump;
 
 import com.marklogic.xcc.*;
-import com.marklogic.xcc.exceptions.MLCloudRequestException;
+import com.marklogic.xcc.exceptions.PDCloudRequestException;
 import com.marklogic.xcc.exceptions.RequestException;
 import com.marklogic.xcc.exceptions.ServerConnectionException;
 import com.marklogic.xcc.types.XSInteger;
@@ -574,9 +574,9 @@ public class ThreadManager implements ConfigConstants {
                                 LOG.warn("ServerConnectionException:" +
                                     e.getMessage() + " . Unable to connect to " +
                                     host + " to query available server max threads.");
-                            } else if (e instanceof MLCloudRequestException) {
-                                isRetryable |= ((MLCloudRequestException)e).isRetryable();
-                                LOG.warn("MLCloudRequestException:" + e.getMessage());
+                            } else if (e instanceof PDCloudRequestException) {
+                                isRetryable |= ((PDCloudRequestException)e).isRetryable();
+                                LOG.warn("PDCloudRequestException:" + e.getMessage());
                             } else {
                                 isRetryable = true;
                                 LOG.warn("RequestException:" + e.getMessage());

--- a/src/main/java/com/marklogic/contentpump/TransformWriter.java
+++ b/src/main/java/com/marklogic/contentpump/TransformWriter.java
@@ -260,10 +260,10 @@ public class TransformWriter<VALUEOUT> extends ContentWriter<VALUEOUT> {
                     } catch (Exception e) {
                         boolean isRetryable = true;
                         LOG.warn("Failed committing transaction.");
-                        if (e instanceof MLCloudRequestException){
-                            isRetryable = ((MLCloudRequestException)e).isRetryable();
+                        if (e instanceof PDCloudRequestException){
+                            isRetryable = ((PDCloudRequestException)e).isRetryable();
                             LOG.warn(getFormattedBatchId() +
-                                "MLCloudRequestException:" + e.getMessage());
+                                "PDCloudRequestException:" + e.getMessage());
                         } else {
                             LOG.warn(getFormattedBatchId() +
                                 "Exception:" + e.getMessage());

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -535,9 +535,9 @@ implements MarkLogicConstants {
                         LOG.warn(getFormattedBatchId() + "QueryException:" +
                             ((QueryException) e).getFormatString());
                         isRetryable = ((RequestException)e).isRetryable();
-                    } else if (e instanceof MLCloudRequestException) {
+                    } else if (e instanceof PDCloudRequestException) {
                         LOG.warn(getFormattedBatchId() +
-                            "MLCloudRequestException:" + e.getMessage());
+                            "PDCloudRequestException:" + e.getMessage());
                         isRetryable = ((RequestException)e).isRetryable();
                     } else if (e instanceof RequestServerException) {
                         // log error and continue on RequestServerException
@@ -686,10 +686,10 @@ implements MarkLogicConstants {
                     } catch (Exception e) {
                         boolean isRetryable = true;
                         LOG.warn("Failed committing transaction.");
-                        if (e instanceof MLCloudRequestException){
-                            isRetryable = ((MLCloudRequestException)e).isRetryable();
+                        if (e instanceof PDCloudRequestException){
+                            isRetryable = ((PDCloudRequestException)e).isRetryable();
                             LOG.warn(getFormattedBatchId() +
-                                "MLCloudRequestException:" + e.getMessage());
+                                "PDCloudRequestException:" + e.getMessage());
                         } else {
                             LOG.warn(getFormattedBatchId() +
                                 "Exception:" + e.getMessage());

--- a/src/main/java/com/marklogic/mapreduce/MarkLogicRecordReader.java
+++ b/src/main/java/com/marklogic/mapreduce/MarkLogicRecordReader.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Collection;
 import java.util.Iterator;
 
-import com.marklogic.xcc.exceptions.MLCloudRequestException;
+import com.marklogic.xcc.exceptions.PDCloudRequestException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -406,9 +406,9 @@ implements MarkLogicConstants {
             throw new IOException(e);
         } catch (RequestException e) {
             boolean isRetryable = true;
-            if (e instanceof MLCloudRequestException){
-                isRetryable = ((MLCloudRequestException)e).isRetryable();
-                LOG.error("MLCloudRequestException:" + e.getMessage());
+            if (e instanceof PDCloudRequestException){
+                isRetryable = ((PDCloudRequestException)e).isRetryable();
+                LOG.error("PDCloudRequestException:" + e.getMessage());
             } else {
                 LOG.error("RequestException:" + e.getMessage());
             }


### PR DESCRIPTION
Since MLCP is using xcc Java class for compilation, marklogic-contentpump/src/lib/[marklogic-xcc-12.0.jar](https://github.com/marklogic/marklogic-contentpump/blob/develop/src/lib/marklogic-xcc-12.0.jar) will be checked in from nightly xcc build, we need to change the MLCloudRequestException to PDCloudRequestException in MLCP.

Test:
1. Compilation
mvn clean package -DskipTests=true  
2. Unit test:
mvn test
3. Regression 06mlcp test
Total test sets: 143  PASS: 137  FAIL: 6
Following tests have failed: 
bug17845.xml
mlcp-basic-8000.xml
mlcp-aggregates-8000.xml
mlcp-export-query-filter.xml
mlcp-ssl-protocal-tls-49273.xml
mlcp-group-host-count.xml

Those tests are expected to fail on my local machine due to the environment setup and missing input test data  


This commit must be merged with https://github.bedford.progress.com/marklogic-platform/xcc/pull/3 at the same time; otherwise, it will cause the nightly build failed
