### PR TITLE
MLE-20647:Netty Project 4.1.100.Final - 0 Rescore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -564,6 +564,14 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-http</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-epoll</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-handler</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Mitigation
Changes to dependency exclusions:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R590-R597): Added exclusions for `netty-transport-native-epoll` and `netty-handler` to prevent them from being included as transitive dependencies.

### Test
1. Compilation
mvn clean package -DskipTests=true
2. Unit test:
mvn test passed 
3. Regression 06mlcp test
06mlcp test suite
Total test sets: 143 PASS: 137 FAIL: 6
Following tests have failed:
bug17845.xml
mlcp-basic-8000.xml
mlcp-aggregates-8000.xml
mlcp-export-query-filter.xml
mlcp-ssl-protocal-tls-49273.xml
mlcp-group-host-count.xml
Same testes failed, those tests are expected to fail on my local machine due to the environment setup (need a cluster) and missing input test data

