### PR TITLE
MLE-21838: (CVE) MLCP - Apache Commons BeanUtils 1.9.4 - Rescore 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -595,6 +595,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-handler</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -1415,7 +1419,8 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>1.11.0</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.thrift</groupId>
@@ -1557,6 +1562,10 @@
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
**Changes**

1. Upgraded the  Commons BeanUtils version to 1.11.0 and reduced the scope to compilation
2. Excluded it from the transitive dependency to force it to use the upgraded version for compilation. 
3. No changes to bindist as it's a compile dependency

**Tests:**
Unit test:  passed
Regression test: 06mlcp passed (Except the expected local failures) 