### PR TITLE
MLE-20182:mlcp import failing with XDMP-DOCSTARTTAGCHAR upon using aggregates as input_file_type option

### DIFF
--- a/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
+++ b/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
@@ -304,7 +304,7 @@ public class AggregateXMLReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
                     if (LOG.isTraceEnabled()) {
                         LOG.trace(nsDeclPrefix + ":" + nsDeclUri);
                     }
-                    if (DEFAULT_NS == nsDeclPrefix) {
+                    if (DEFAULT_NS == nsDeclPrefix || ("".equals(nsDeclPrefix))) {
                         sb.append(" xmlns=\"" + nsDeclUri + "\"");
                     } else {
                         sb.append(" xmlns:" + nsDeclPrefix + "=\"" + nsDeclUri

--- a/src/test/java/com/marklogic/contentpump/TestImportAggregate.java
+++ b/src/test/java/com/marklogic/contentpump/TestImportAggregate.java
@@ -601,4 +601,28 @@ public class TestImportAggregate {
         assertEquals("2", result.next().asString());
         Utils.closeSession();
     }
+
+    @Test
+    public void testBug20182() throws Exception {
+        String cmd = "IMPORT -host localhost -username admin -password"
+            + " admin -input_file_path " + Constants.TEST_PATH.toUri()
+            + "/agg/20182.xml"
+            + " -thread_count 1"
+            + " -input_file_type aggregates"
+            + " -port " + Constants.port + " -database " + Constants.testDb;
+        String[] args = cmd.split(" ");
+        assertFalse(args.length == 0);
+
+        Utils.clearDB(Utils.getTestDbXccUri(), Constants.testDb);
+
+        String[] expandedArgs = null;
+        expandedArgs = OptionsFileUtil.expandArguments(args);
+        ContentPump.runCommand(expandedArgs);
+
+        ResultSequence result = Utils.runQuery(
+            Utils.getTestDbXccUri(), "fn:count(fn:collection())");
+        assertTrue(result.hasNext());
+        assertEquals("2", result.next().asString());
+        Utils.closeSession();
+    }
 }

--- a/src/test/resources/agg/20182.xml
+++ b/src/test/resources/agg/20182.xml
@@ -1,0 +1,10 @@
+<people>
+    <person>
+        <first xmlns="http://marklogic.com/examples">George</first>
+        <last>Washington</last>
+    </person>
+    <person>
+        <first xmlns="http://marklogic.com/examples">Betsy</first>
+        <last>Ross</last>
+    </person>
+</people>


### PR DESCRIPTION
### Root cause
In the file AggregateXMLReader.java, inside the processStartElement() function, at line 302:

`nsDeclPrefix = xmlSR.getNamespacePrefix(i);`

When MLCP tries to get the prefix for the namespace, MLCP uses getNamespacePrefix function (this is the function from the official Java XML Stream Reader). 

In Java8, getNamespacePrefix() will return null if this is the default namespace declaration

In Java11. getNamespacePrefix() will return “” (empty) if this is the default namespace declaration

This functional change leads to a false condition between lines 307 and 311, which appends an extra invalid “=\” character.

```
if (DEFAULT_NS == nsDeclPrefix) {
	 sb.append(" xmlns=\"" + nsDeclUri + "\"");
	} else {
		sb.append(" xmlns:" + nsDeclPrefix + "=\"" + nsDeclUri + "\"");
```

This is the root cause of the issue and explains why it did not occur in versions before MLCP 10.0.6( using Java 8 here)

### Solution/Changes
1. Add check for empty prefix of namespace
```
                   if (DEFAULT_NS == nsDeclPrefix || ("".equals(nsDeclPrefix))) {
                        sb.append(" xmlns=\"" + nsDeclUri + "\"");
                    } else {
                        sb.append(" xmlns:" + nsDeclPrefix + "=\"" + nsDeclUri
                            + "\"");
                    }
```
2. Add one more Junit test: testBug20182

### Test
mvn test: Passed
Regression Test: make tests tname=06mlcp 
Total test sets: 143  PASS: 137  FAIL: 6
There are expected failures on local machine
