### PR TITLE
MLE-26838: Added null check for conf.getStrings() method

### DIFF
--- a/src/main/java/com/marklogic/contentpump/InputType.java
+++ b/src/main/java/com/marklogic/contentpump/InputType.java
@@ -249,6 +249,10 @@ public enum InputType implements ConfigConstants {
             ContentSource cs;
             String[] outputHosts =
                     conf.getStrings(MarkLogicConstants.OUTPUT_HOST);
+            if (outputHosts == null || outputHosts.length == 0) {
+                throw new IllegalArgumentException(MarkLogicConstants.OUTPUT_HOST + 
+                        " is not specified.");
+            }
             int hostIdx = 0;
             while (hostIdx < outputHosts.length) {
                 try {

--- a/src/main/java/com/marklogic/contentpump/RDFReader.java
+++ b/src/main/java/com/marklogic/contentpump/RDFReader.java
@@ -546,8 +546,13 @@ public class RDFReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
         ResultSequence result = null;
         ContentSource cs;
         try {
+            String[] hosts = conf.getStrings(MarkLogicConstants.OUTPUT_HOST);
+            if (hosts == null || hosts.length == 0) {
+                throw new IllegalArgumentException(MarkLogicConstants.OUTPUT_HOST + 
+                        " is not specified.");
+            }
             cs = InternalUtilities.getOutputContentSource(conf,
-                conf.getStrings(MarkLogicConstants.OUTPUT_HOST)[0]);
+                hosts[0]);
             session = cs.newSession();
             RequestOptions options = new RequestOptions();
             options.setDefaultXQueryVersion("1.0-ml");

--- a/src/main/java/com/marklogic/contentpump/ThreadManager.java
+++ b/src/main/java/com/marklogic/contentpump/ThreadManager.java
@@ -548,6 +548,12 @@ public class ThreadManager implements ConfigConstants {
             boolean isRetryable = false;
             pollingRetry = 0;
             pollingSleepTime = MIN_SLEEP_TIME;
+            String[] hosts = conf.getStrings(MarkLogicConstants.OUTPUT_HOST);
+            if (hosts == null || hosts.length == 0) {
+                LOG.error(MarkLogicConstants.OUTPUT_HOST + " is not specified.");
+                job.setJobState(JobStatus.State.FAILED);
+                return;
+            }
             // Poll server max threads
             while (pollingRetry < MAX_RETRIES) {
                 if (pollingRetry > 0) {
@@ -555,7 +561,6 @@ public class ThreadManager implements ConfigConstants {
                         LOG.debug("Retrying querying available server max threads.");
                     }
                 }
-                String[] hosts = conf.getStrings(MarkLogicConstants.OUTPUT_HOST);
                 for (String host : hosts) {
                     try {
                         ContentSource cs = InternalUtilities.

--- a/src/main/java/com/marklogic/contentpump/TransformOutputFormat.java
+++ b/src/main/java/com/marklogic/contentpump/TransformOutputFormat.java
@@ -75,6 +75,10 @@ public class TransformOutputFormat<VALUEOUT> extends
             return mimetypeMap;
         }
         String[] hosts = conf.getStrings(OUTPUT_HOST);
+        if (hosts == null || hosts.length == 0) {
+            throw new IllegalArgumentException(OUTPUT_HOST + 
+                    " is not specified.");
+        }
         Session session = null;
         ResultSequence result = null;
 

--- a/src/main/java/com/marklogic/contentpump/utilities/PermissionUtil.java
+++ b/src/main/java/com/marklogic/contentpump/utilities/PermissionUtil.java
@@ -79,8 +79,13 @@ public class PermissionUtil {
         ResultSequence result = null;
         ContentSource cs;
         try {
+            String[] hosts = conf.getStrings(MarkLogicConstants.OUTPUT_HOST);
+            if (hosts == null || hosts.length == 0) {
+                throw new IllegalArgumentException(MarkLogicConstants.OUTPUT_HOST + 
+                        " is not specified.");
+            }
             cs = InternalUtilities.getOutputContentSource(conf,
-                conf.getStrings(MarkLogicConstants.OUTPUT_HOST)[0]);
+                hosts[0]);
 
             session = cs.newSession();
             RequestOptions options = new RequestOptions();

--- a/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
@@ -224,6 +224,10 @@ public class ContentOutputFormat<VALUEOUT> extends
                 TextArrayWritable hostArray = null;
                 if (restrictHosts) {
                     String[] outputHosts = conf.getStrings(OUTPUT_HOST);
+                    if (outputHosts == null || outputHosts.length == 0) {
+                        throw new IllegalArgumentException(OUTPUT_HOST + 
+                                " is not specified.");
+                    }
                     hostArray = new TextArrayWritable(outputHosts);
                 } else {
                     String outputHost = cs.getConnectionProvider().getHostName();

--- a/src/main/java/com/marklogic/mapreduce/utilities/InternalUtilities.java
+++ b/src/main/java/com/marklogic/mapreduce/utilities/InternalUtilities.java
@@ -104,13 +104,12 @@ public class InternalUtilities implements MarkLogicConstants {
      */
     public static ContentSource getInputContentSource(Configuration conf) 
     throws URISyntaxException, XccConfigException, IOException {
-        String host = conf.getStrings(INPUT_HOST)[0];
-        if (host == null || host.isEmpty()) {
+        String[] hosts = conf.getStrings(INPUT_HOST);
+        if (hosts == null || hosts.length == 0) {
             throw new IllegalArgumentException(INPUT_HOST + 
                     " is not specified.");
         }
-        
-        return getInputContentSource(conf, host);
+        return getInputContentSource(conf, hosts[0]);
     }
     
     /**


### PR DESCRIPTION
As part of Polaris Null Pointer Dereference issues cleanup, I have added null checks for the conf.getStrings() method in the following files:

    InternalUtilities.java
    PermissionUtil.java
    RDFReader.java
    InputType.java
    ThreadManager.java
    TransformOutputFormat.java
    ContentOutputFormat.java