### PR TITLE
MLE-27155 : (CVE) MLCP - Apache Avro 1.11.4 - 7.3 HIGH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1612,7 +1612,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.4</version>
+      <version>1.11.5</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
I have upgraded the Avro version to a safer version suggested in CVE. 

The following tests run successfully. 

1. MLCP unit tests 
2. 06mlcp,mlcp-semantics,mlcp-redaction,mlcp-bitemporal test suites
