### PR TITLE
MLE-27155 : (CVE) MLCP - Apache Avro 1.11.4 - 7.3 HIGH (#566)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1612,7 +1612,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.4</version>
+      <version>1.11.5</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
I have upgraded the Avro version to a safer version suggested in CVE.

Unit tests ran successfully with 11.3 XCC. 