### PR TITLE
MLE-27155 : (CVE) MLCP - Apache Avro 1.11.4 - 7.3 HIGH (#566)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1615,7 +1615,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.4</version>
+      <version>1.11.5</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Cherrypicking the Avro upgrade commit to develop. 

The following tests run successfully.

1. MLCP unit tests
2. 06mlcp