### PR TITLE
MLE-27553 MLE-27554 MLE-27555 MLE-27556: Fix XXE Injection - XML External Entity Polaris medium severity issues

### DIFF
--- a/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
+++ b/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
@@ -112,9 +112,13 @@ public class AggregateXMLReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
         f = XMLInputFactory.newInstance();
         try {
             f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Failed configuring XXE-prevention security property IS_SUPPORTING_EXTERNAL_ENTITIES on XMLInputFactory", e);
+        }
+        try {
             f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         } catch (IllegalArgumentException e) {
-            LOG.warn("Unable to set XXE safety properties on XMLInputFactory", e);
+            LOG.warn("Failed configuring XXE-prevention security property SUPPORT_DTD on XMLInputFactory", e);
         }
         setFile(((FileSplit) inSplit).getPath());
         fs = file.getFileSystem(context.getConfiguration());

--- a/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
+++ b/src/main/java/com/marklogic/contentpump/AggregateXMLReader.java
@@ -110,6 +110,12 @@ public class AggregateXMLReader<VALUEIN> extends ImportRecordReader<VALUEIN> {
         initAggConf(context);
         
         f = XMLInputFactory.newInstance();
+        try {
+            f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Unable to set XXE safety properties on XMLInputFactory", e);
+        }
         setFile(((FileSplit) inSplit).getPath());
         fs = file.getFileSystem(context.getConfiguration());
         FileStatus status = fs.getFileStatus(file);

--- a/src/main/java/com/marklogic/contentpump/CompressedAggXMLReader.java
+++ b/src/main/java/com/marklogic/contentpump/CompressedAggXMLReader.java
@@ -71,9 +71,13 @@ public class CompressedAggXMLReader<VALUEIN> extends
         f = XMLInputFactory.newInstance();
         try {
             f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Failed configuring XXE-prevention security property IS_SUPPORTING_EXTERNAL_ENTITIES on XMLInputFactory", e);
+        }
+        try {
             f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
         } catch (IllegalArgumentException e) {
-            LOG.warn("Unable to set XXE safety properties on XMLInputFactory", e);
+            LOG.warn("Failed configuring XXE-prevention security property SUPPORT_DTD on XMLInputFactory", e);
         }
         setFile(((FileSplit) inSplit).getPath());
         fs = file.getFileSystem(context.getConfiguration());

--- a/src/main/java/com/marklogic/contentpump/CompressedAggXMLReader.java
+++ b/src/main/java/com/marklogic/contentpump/CompressedAggXMLReader.java
@@ -69,6 +69,12 @@ public class CompressedAggXMLReader<VALUEIN> extends
         initConfig(context);
         initAggConf(context);
         f = XMLInputFactory.newInstance();
+        try {
+            f.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            f.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("Unable to set XXE safety properties on XMLInputFactory", e);
+        }
         setFile(((FileSplit) inSplit).getPath());
         fs = file.getFileSystem(context.getConfiguration());
 

--- a/src/main/java/com/marklogic/mapreduce/DOMDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/DOMDocument.java
@@ -71,9 +71,13 @@ public class DOMDocument extends ForestDocument {
             transformerFactory = TransformerFactory.newInstance();
             try {
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Failed configuring XXE-prevention security attribute ACCESS_EXTERNAL_DTD on TransformerFactory", e);
+            }
+            try {
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             } catch (IllegalArgumentException e) {
-                LOG.warn("Unable to set XXE safety attributes on TransformerFactory", e);
+                LOG.warn("Failed configuring XXE-prevention security attribute ACCESS_EXTERNAL_STYLESHEET on TransformerFactory", e);
             }
         }
 

--- a/src/main/java/com/marklogic/mapreduce/DOMDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/DOMDocument.java
@@ -21,6 +21,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -68,6 +69,12 @@ public class DOMDocument extends ForestDocument {
     private static synchronized TransformerFactory getTransformerFactory() {
         if (transformerFactory == null) {
             transformerFactory = TransformerFactory.newInstance();
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Unable to set XXE safety attributes on TransformerFactory", e);
+            }
         }
 
         return transformerFactory;

--- a/src/main/java/com/marklogic/mapreduce/JSONDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/JSONDocument.java
@@ -20,6 +20,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.TransformerFactory;
 
 import org.apache.commons.logging.Log;
@@ -48,6 +49,12 @@ public class JSONDocument extends ForestDocument {
     private static synchronized TransformerFactory getTransformerFactory() {
         if (transformerFactory == null) {
             transformerFactory = TransformerFactory.newInstance();
+            try {
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Unable to set XXE safety attributes on TransformerFactory", e);
+            }
         }
 
         return transformerFactory;

--- a/src/main/java/com/marklogic/mapreduce/JSONDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/JSONDocument.java
@@ -51,9 +51,13 @@ public class JSONDocument extends ForestDocument {
             transformerFactory = TransformerFactory.newInstance();
             try {
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (IllegalArgumentException e) {
+                LOG.warn("Failed configuring XXE-prevention security attribute ACCESS_EXTERNAL_DTD on TransformerFactory", e);
+            }
+            try {
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
             } catch (IllegalArgumentException e) {
-                LOG.warn("Unable to set XXE safety attributes on TransformerFactory", e);
+                LOG.warn("Failed configuring XXE-prevention security attribute ACCESS_EXTERNAL_STYLESHEET on TransformerFactory", e);
             }
         }
 


### PR DESCRIPTION
### **Problem**

XML parsers were created without disabling external entity resolution (CWE-611), which could allow XXE attacks including arbitrary file reads, SSRF, and denial of service via entity expansion.

---

### **Changes**

#### **1. XMLInputFactory (StAX parsers)**

**Files:**

* `AggregateXMLReader.java`
* `CompressedAggXMLReader.java`

Used `setProperty` (correct API for StAX):

Disabled:

* `XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES = false`
* `XMLInputFactory.SUPPORT_DTD = false`


#### **2. TransformerFactory (XSLT processing)**

**Files:**

* `DOMDocument.java`
* `JSONDocument.java`

Used `setAttribute` (correct API for transformers):

Disabled:

* `XMLConstants.ACCESS_EXTERNAL_DTD = ""`
* `XMLConstants.ACCESS_EXTERNAL_STYLESHEET = ""`



Wrapped property/attribute configuration in `try-catch (IllegalArgumentException)`
Logs a warning if a property is unsupported


### **Testing**

* Ran unit tests for sanity check→ All passed

#### **06mlcp test suite results**

The following tests are failing:

* `bug17845.xml`
* `mlcp-basic-8000.xml`
* `mlcp-aggregates-8000.xml`
* `mlcp-ssl-protocal-tls-49273.xml`
* `mlcp-export-query-filter.xml`
* `mlcp-group-host-count.xml`

same failures exist without the changes.

