### PR TITLE
MLE-27557: Fix weak crypto - replace insecure TLSv1 with TLSv1.3 in ContentReader.java

### DIFF
--- a/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
+++ b/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
@@ -97,21 +97,19 @@ public class ContentReader {
     static class SslOptions implements SslConfigOptions {
         @Override
         public String[] getEnabledCipherSuites() {
-            return new String[] { "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
-                    "TLS_DHE_DSS_WITH_AES_256_CBC_SHA", 
-            "TLS_RSA_WITH_AES_256_CBC_SHA" };
+            return null;
         }
 
         @Override
         public String[] getEnabledProtocols() {
-            return new String[] { "TLSv1" };
+            return new String[] { "TLSv1.3" };
         }
         
         @Override
         public SSLContext getSslContext() {
             SSLContext sslContext = null;
             try {
-                sslContext = SSLContext.getInstance("TLSv1");
+                sslContext = SSLContext.getInstance("TLSv1.3");
             } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This PR addresses a weak cryptography security issue (MLE-27557) by replacing the insecure TLSv1 protocol with TLSv1.3 in `ContentReader.java`. TLSv1 is considered cryptographically weak and vulnerable to various attacks. Upgrading to TLSv1.3 ensures stronger encryption and improved security posture.

Ran the 06mlcp test suite — no regression failures were found in testing.