### PR TITLE
MLE-26865, MLE-26867: Fixes for issues identified by Polaris

### DIFF
--- a/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
+++ b/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -263,6 +264,7 @@ public class LocalJobRunner implements ConfigConstants {
         private Class<? extends Mapper<?,?,?,?>> mapperClass;
         private int threadCount = 0;
         private AtomicBoolean isTaskDone = new AtomicBoolean(false);
+        private CountDownLatch runnersLatch = new CountDownLatch(1);
         
         public LocalMapTask(InputFormat<INKEY, INVALUE> inputFormat, 
                 OutputFormat<OUTKEY, OUTVALUE> outputFormat, 
@@ -310,6 +312,10 @@ public class LocalJobRunner implements ConfigConstants {
             return isTaskDone.get();
         }
 
+        public CountDownLatch getRunnersLatch() {
+            return runnersLatch;
+        }
+
 		@SuppressWarnings("unchecked")
         @Override
         public Object call() {
@@ -339,6 +345,7 @@ public class LocalJobRunner implements ConfigConstants {
                 if (mapperClass == (Class)MultithreadedMapper.class) {
                 	((MultithreadedMapper)mapper).setThreadCount(threadCount);
                     ((MultithreadedMapper)mapper).setThreadPool(pool);
+                    ((MultithreadedMapper)mapper).setRunnersLatch(runnersLatch);
                 }
                 mapper.run(mapperContext);
             } catch (Throwable t) {
@@ -349,9 +356,7 @@ public class LocalJobRunner implements ConfigConstants {
                     LOG.error(t.getMessage());
                 }
                 try {
-                    synchronized(pool) {
-                        pool.notify();
-                    }
+                    runnersLatch.countDown();
                 } catch (Throwable t1) {
                     LOG.error(t1);
                 }

--- a/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
+++ b/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -57,6 +58,7 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
     private List<Future<?>> runnerFutureList = new ArrayList<>();
     private int threadCount = 0;
     private ThreadPoolExecutor threadPool;
+    private CountDownLatch runnersLatch;
 
     /**
      * Get thread count set for this mapper.
@@ -84,6 +86,10 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
 	 */
 	public void setThreadPool(ThreadPoolExecutor pool) {
 		this.threadPool = pool;
+	}
+
+	public void setRunnersLatch(CountDownLatch latch) {
+		this.runnersLatch = latch;
 	}
 
 	/**
@@ -174,7 +180,9 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
                     }
                 }
             }
-            threadPool.notify();
+            if (runnersLatch != null) {
+                runnersLatch.countDown();
+            }
         }
     }
 

--- a/src/main/java/com/marklogic/contentpump/ThreadManager.java
+++ b/src/main/java/com/marklogic/contentpump/ThreadManager.java
@@ -458,10 +458,8 @@ public class ThreadManager implements ConfigConstants {
         }
         taskList.add(task);
         if (runtimeMapperClass == (Class)MultithreadedMapper.class) {
-            synchronized (pool) {
-                taskFutureList.add(pool.submit(task));
-                pool.wait();
-            }
+            taskFutureList.add(pool.submit(task));
+            task.getRunnersLatch().await();
         } else {
             pool.submit(task);
         }

--- a/src/main/java/com/marklogic/contentpump/ThreadManager.java
+++ b/src/main/java/com/marklogic/contentpump/ThreadManager.java
@@ -604,6 +604,7 @@ public class ThreadManager implements ConfigConstants {
             }
             // Collect active task counts and idle thread counts
             int activeTaskCounts = getActiveTaskCounts();
+            if (activeTaskCounts == 0) return;
             prepareRandomIndexes(activeTaskCounts);
             if (curServerThreads < newServerThreads) {
                 // Scale out


### PR DESCRIPTION
This PR contains fixes for two issues identified through Polaris scans:

    MLE-26865: Using pool.wait()/notify() makes the code vulnerable to spurious wakeups. This was fixed by replacing it with CountDownLatch instead.
    MLE-24515: Potential divide by zero issue where getActiveTaskCounts() returns 0.

I ran the unit test and 06mlcp, both passing with no failures other than expected ones.