### PR TITLE
MLE-26818 MLE-26835: Fix Polaris Unwritten Field and Useless Call

### DIFF
--- a/src/main/java/com/marklogic/contentpump/ColumnDataType.java
+++ b/src/main/java/com/marklogic/contentpump/ColumnDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public enum ColumnDataType {
     NUMBER {
         @Override
         public Object parse(String s) throws Exception {
-            s.trim();
+            s = s.trim();
             if ("".equals(s)) {
                 throw new Exception("missing value");
             }
@@ -46,14 +46,14 @@ public enum ColumnDataType {
     BOOLEAN {
         @Override
         public Object parse(String s) throws Exception {
-            s.trim();
+            s = s.trim();
             if ("".equals(s)) {
                 throw new Exception("missing value");
             } else if (!"true".equalsIgnoreCase(s) && 
                     !"false".equalsIgnoreCase(s)) {
                 throw new ParseException("", 0);
             }
-            return new Boolean(s);
+            return Boolean.valueOf(s);
         }
         
     };

--- a/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
+++ b/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -417,6 +417,7 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
             try {
                 mapper.runThreadSafe(outer, subcontext, this);
             } catch (Throwable ie) {
+                throwable = ie;
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Error running task:" + ie);
                     ie.printStackTrace();
@@ -425,6 +426,9 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
             try {
                 writer.close(subcontext);
             } catch (Throwable t) {
+                if (throwable == null) {
+                    throwable = t;
+                }
                 LOG.error("Error closing writer: " + t.getMessage());
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(t);


### PR DESCRIPTION

 ## Changes

 ### MLE-26818 — useless call in `ColumnDataType.java`
 - `s.trim()` was called but the result was discarded (strings are immutable in Java).
   Fixed to `s = s.trim()` in both `NUMBER.parse()` and `BOOLEAN.parse()`.
 - `new Boolean(s)` uses the deprecated `Boolean` constructor.
   Replaced with `Boolean.valueOf(s)` which avoids unnecessary object allocation.

 ### MLE-26835 — Unwritten field in `MultithreadedMapper.java`
 - `throwable` is declared on `MapRunner` but never initialized — defaulting to `null`:

    ` private Throwable throwable;`

 - It is read after each thread completes to propagate exceptions to the caller:

    ``` Throwable th = thread.throwable;
     if (th != null) {
         if (th instanceof IOException) throw (IOException) th;
         else if (th instanceof InterruptedException) throw (InterruptedException) th;
         else throw new RuntimeException(th);
     }

 - Without `throwable = ie` in the catch block, the field was never written on error —
 always staying `null`. This made the entire exception-propagation path dead code:
 exceptions from `runThreadSafe()` were silently swallowed and never rethrown,
 causing failures to go unreported.

 - Fixed by assigning `throwable = ie` in the catch block. Also guarded the `writer.close()`
 catch to only assign `throwable` if not already set, preserving the original root cause.

 ## Files Changed
 - `src/main/java/com/marklogic/contentpump/ColumnDataType.java`
 - `src/main/java/com/marklogic/contentpump/MultithreadedMapper.java`

## Tests

- Ran unit tests → All passed
- Ran 06mlcp test suite — no regression failures were found in testing.