### PR TITLE
MLE-26816 MLE-26817: Fix Polaris copy-paste error and comparing incompatible types

### DIFF
--- a/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -736,7 +736,7 @@ public class DatabaseContentReader extends
         Node role;
         Node capability;
         Node id;
-        if (0 < roles.getLength() && 0 < capabilities.getLength()) {
+        if (0 < roles.getLength() && 0 < capabilities.getLength() && 0 < ids.getLength()) {
             role = roles.item(0);
             capability = capabilities.item(0);
             id = ids.item(0);
@@ -750,7 +750,7 @@ public class DatabaseContentReader extends
                 LOG.warn("input permission: " + permissionW3cElement + ": "
                     + capabilities.getLength() + " capabilities, using only 1");
             }
-            if (capabilities.getLength() > 1) {
+            if (ids.getLength() > 1) {
                 LOG.warn("input permission: " + permissionW3cElement + ": "
                     + ids.getLength() + " ids, using only 1");
             }
@@ -763,6 +763,10 @@ public class DatabaseContentReader extends
             if (capabilities.getLength() < 1) {
                 LOG.warn("skipping input permission: " + permissionW3cElement
                     + ": no capabilities");
+            }
+            if (ids.getLength() < 1) {
+                LOG.warn("skipping input permission: " + permissionW3cElement
+                    + ": no ids");
             }
         }
 

--- a/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
+++ b/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,20 +222,21 @@ public class DocumentMetadata {
      * @param _format
      */
     public void setFormat(String _format) {
-        if (_format.equals(DocumentFormat.XML)
-                || _format.equals("element") || _format.equals("comment")
-                || _format.equals("processing-instruction")) {
+        if (DocumentFormat.XML.toString().equals(_format)
+                || "element".equals(_format) || "comment".equals(_format)
+                || "processing-instruction".equals(_format)) {
             setFormat(DocumentFormat.XML);
             return;
         }
 
-        if (_format.equals(DocumentFormat.TEXT)
-                || _format.equals(("text"))) {
+        if (DocumentFormat.TEXT.toString().equals(_format)
+                || "text".equals(_format)) {
             setFormat(DocumentFormat.TEXT);
             return;
         }
- 
-        if (_format.equals(DocumentFormat.BINARY)) {
+
+        if (DocumentFormat.BINARY.toString().equals(_format)
+                || "binary".equals(_format)) {
             setFormat(DocumentFormat.BINARY);
             return;
         }


### PR DESCRIPTION
 ## Changes

 ### MLE-26816 — Copy-paste error in `DatabaseContentReader.java`
 - The guard condition for entering the permission-parsing block was missing a check on `ids.getLength()`,
   allowing entry even when `ids` is empty — leading to a potential NPE on `ids.item(0)`.
 - The warning log for "using only 1 id" was incorrectly checking `capabilities.getLength() > 1`
   instead of `ids.getLength() > 1` (copy-paste error).
 - Added a missing warning when `ids` is empty, consistent with the existing "no capabilities" warning.

 ### MLE-26817 — Comparing incompatible types in `DocumentMetadata.java`
 - `_format.equals(DocumentFormat.XML/TEXT/BINARY)` was comparing a `String` against an enum value,
   which always evaluates to `false` at runtime.
 - Fixed by calling `.toString()` on the enum values before comparison.
 - Switched to "Yoda" style (`"literal".equals(variable)`) to guard against potential NPEs.
 - Added missing `"binary"` string check for `DocumentFormat.BINARY` to align with the other cases.

 ## Files Changed
 - `src/main/java/com/marklogic/contentpump/DatabaseContentReader.java`
 - `src/main/java/com/marklogic/contentpump/DocumentMetadata.java`

## Tests
- Ran unit tests → All passed
- Ran 06mlcp test suite — no regression failures were found in testing.