### PR TITLE
MLE-29123 MLE-29124 MLE-29125 MLE-29126:  Fix Polaris CWE medium severity in MLCP (Backport)

### DIFF
--- a/src/main/java/com/marklogic/contentpump/ColumnDataType.java
+++ b/src/main/java/com/marklogic/contentpump/ColumnDataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public enum ColumnDataType {
     NUMBER {
         @Override
         public Object parse(String s) throws Exception {
-            s.trim();
+            s = s.trim();
             if ("".equals(s)) {
                 throw new Exception("missing value");
             }
@@ -46,14 +46,14 @@ public enum ColumnDataType {
     BOOLEAN {
         @Override
         public Object parse(String s) throws Exception {
-            s.trim();
+            s = s.trim();
             if ("".equals(s)) {
                 throw new Exception("missing value");
             } else if (!"true".equalsIgnoreCase(s) && 
                     !"false".equalsIgnoreCase(s)) {
                 throw new ParseException("", 0);
             }
-            return new Boolean(s);
+            return Boolean.valueOf(s);
         }
         
     };

--- a/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -703,7 +703,7 @@ public class DatabaseContentReader extends
         Node role;
         Node capability;
         Node id;
-        if (0 < roles.getLength() && 0 < capabilities.getLength()) {
+        if (0 < roles.getLength() && 0 < capabilities.getLength() && 0 < ids.getLength()) {
             role = roles.item(0);
             capability = capabilities.item(0);
             id = ids.item(0);
@@ -717,7 +717,7 @@ public class DatabaseContentReader extends
                 LOG.warn("input permission: " + permissionW3cElement + ": "
                     + capabilities.getLength() + " capabilities, using only 1");
             }
-            if (capabilities.getLength() > 1) {
+            if (ids.getLength() > 1) {
                 LOG.warn("input permission: " + permissionW3cElement + ": "
                     + ids.getLength() + " ids, using only 1");
             }
@@ -730,6 +730,10 @@ public class DatabaseContentReader extends
             if (capabilities.getLength() < 1) {
                 LOG.warn("skipping input permission: " + permissionW3cElement
                     + ": no capabilities");
+            }
+            if (ids.getLength() < 1) {
+                LOG.warn("skipping input permission: " + permissionW3cElement
+                    + ": no ids");
             }
         }
 

--- a/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
+++ b/src/main/java/com/marklogic/contentpump/DocumentMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2022 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,20 +222,21 @@ public class DocumentMetadata {
      * @param _format
      */
     public void setFormat(String _format) {
-        if (_format.equals(DocumentFormat.XML)
-                || _format.equals("element") || _format.equals("comment")
-                || _format.equals("processing-instruction")) {
+        if (DocumentFormat.XML.toString().equals(_format)
+                || "element".equals(_format) || "comment".equals(_format)
+                || "processing-instruction".equals(_format)) {
             setFormat(DocumentFormat.XML);
             return;
         }
 
-        if (_format.equals(DocumentFormat.TEXT)
-                || _format.equals(("text"))) {
+        if (DocumentFormat.TEXT.toString().equals(_format)
+                || "text".equals(_format)) {
             setFormat(DocumentFormat.TEXT);
             return;
         }
- 
-        if (_format.equals(DocumentFormat.BINARY)) {
+
+        if (DocumentFormat.BINARY.toString().equals(_format)
+                || "binary".equals(_format)) {
             setFormat(DocumentFormat.BINARY);
             return;
         }

--- a/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
+++ b/src/main/java/com/marklogic/contentpump/MultithreadedMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -409,6 +409,7 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
             try {
                 mapper.runThreadSafe(outer, subcontext, this);
             } catch (Throwable ie) {
+                throwable = ie;
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Error running task:" + ie);
                     ie.printStackTrace();
@@ -417,6 +418,9 @@ public class MultithreadedMapper<K1, V1, K2, V2> extends
             try {
                 writer.close(subcontext);
             } catch (Throwable t) {
+                if (throwable == null) {
+                    throwable = t;
+                }
                 LOG.error("Error closing writer: " + t.getMessage());
                 if (LOG.isDebugEnabled()) {
                     LOG.debug(t);


### PR DESCRIPTION
These changes have already been validated on the develop branch in these PRs.

1. https://github.com/marklogic/marklogic-contentpump/pull/595
2. https://github.com/marklogic/marklogic-contentpump/pull/596

## Changes

### MLE-29123 — Copy-paste error in `DatabaseContentReader.java`
- The guard condition for entering the permission-parsing block was missing a check on `ids.getLength()`, allowing entry even when `ids` is empty — leading to a potential NPE on `ids.item(0)`.  
- The warning log for "using only 1 id" was incorrectly checking `capabilities.getLength() > 1` instead of `ids.getLength() > 1` (copy-paste error).  
- Added a missing warning when `ids` is empty, consistent with the existing "no capabilities" warning.

### MLE-29126 — Comparing incompatible types in `DocumentMetadata.java`
- `_format.equals(DocumentFormat.XML/TEXT/BINARY)` was comparing a `String` against an enum value, which always evaluates to `false` at runtime.  
- Fixed by calling `.toString()` on the enum values before comparison.  
- Switched to "Yoda" style (`"literal".equals(variable)`) to guard against potential NPEs.  
- Added missing `"binary"` string check for `DocumentFormat.BINARY` to align with the other cases.

### MLE-29125 — Useless call in `ColumnDataType.java`
- `s.trim()` was called but the result was discarded (strings are immutable in Java).  
- Fixed to `s = s.trim()` in both `NUMBER.parse()` and `BOOLEAN.parse()`.  
- `new Boolean(s)` uses the deprecated `Boolean` constructor.  
- Replaced with `Boolean.valueOf(s)` which avoids unnecessary object allocation.

### MLE-29124 — Unwritten field in `MultithreadedMapper.java`
- `throwable` is declared on `MapRunner` but never initialized — defaulting to `null`:

    private Throwable throwable;

- It is read after each thread completes to propagate exceptions to the caller:

    if (th != null) {
        if (th instanceof IOException) throw (IOException) th;
        else if (th instanceof InterruptedException) throw (InterruptedException) th;
        else throw new RuntimeException(th);
    }

- Without `throwable = ie` in the catch block, the field was never written on error — always staying `null`.  
- This made the entire exception-propagation path dead code: exceptions from `runThreadSafe()` were silently swallowed and never rethrown, causing failures to go unreported.

- Fixed by assigning `throwable = ie` in the catch block. Also guarded the `writer.close()` catch to only assign `throwable` if not already set, preserving the original root cause.

## Files Changed
- `src/main/java/com/marklogic/contentpump/DatabaseContentReader.java`
- `src/main/java/com/marklogic/contentpump/DocumentMetadata.java`
- `src/main/java/com/marklogic/contentpump/ColumnDataType.java`
- `src/main/java/com/marklogic/contentpump/MultithreadedMapper.java`

## Tests
- Ran unit tests → All passed  
- Ran `06mlcp` test suite → No regression failures were found