### PR TITLE
MLE-26858 MLE-26901 MLE-26837: Fix Polaris bitwise shift, null-like value, and insufficient logging

### DIFF
--- a/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,6 @@ public class DatabaseContentWriter<VALUE> extends
     public static final String XQUERY_VERSION_1_0_ML = 
             "xquery version \"1.0-ml\";\n";
 
-    public DatabaseContentWriter(Configuration conf,
-        Map<String, ContentSource> hostSourceMap, boolean fastLoad) {
-        this(conf, hostSourceMap, fastLoad, null); 
-    }
-    
     public DatabaseContentWriter(Configuration conf,
             Map<String, ContentSource> hostSourceMap, boolean fastLoad,
             AssignmentManager am) {

--- a/src/main/java/com/marklogic/io/Decoder.java
+++ b/src/main/java/com/marklogic/io/Decoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,11 @@ public class Decoder {
         long val = reg & ((nbits < 64) ? ((1L << nbits) - 1) : -1L);
         for (int i = 0; i < nbits; i += 4)
             val += (1L << i);
-        reg >>>= nbits;
+        if (nbits >= 64) {
+            reg = 0;
+        } else {
+            reg >>>= nbits;
+        }
         numBitsInReg -= nbits;
         return (int)(val & 0xffffffffL);
     }
@@ -182,7 +186,11 @@ public class Decoder {
         if (n > numBitsInReg)
             load();
         long v = reg & ((n < 64) ? ((1L << n) - 1) : -1L);
-        reg >>>= n;
+        if (n >= 64) {
+            reg = 0;
+        } else {
+            reg >>>= n;
+        }
         numBitsInReg -= n;
         return (int)(v & 0xffffffffL);
     }

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,11 +198,6 @@ implements MarkLogicConstants {
 
     protected final int MAX_SLEEP_TIME = 120000;
 
-    
-    public ContentWriter(Configuration conf, 
-        Map<String, ContentSource> hostSourceMap, boolean fastLoad) {
-        this(conf, hostSourceMap, fastLoad, null);
-    }
     
     public ContentWriter(Configuration conf,
         Map<String, ContentSource> hostSourceMap, boolean fastLoad,

--- a/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
+++ b/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,9 @@ public class ContentReader {
     }
     
     static class SslOptions implements SslConfigOptions {
+        public static final Log LOG =
+            LogFactory.getLog(SslOptions.class);
+
         @Override
         public String[] getEnabledCipherSuites() {
             return null;
@@ -111,7 +114,7 @@ public class ContentReader {
             try {
                 sslContext = SSLContext.getInstance("TLSv1.3");
             } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
+                LOG.error("Error creating SSLContext", e);
             }
             TrustManager[] trustManagers = null;
             // Trust anyone.
@@ -135,7 +138,7 @@ public class ContentReader {
             try {
                 sslContext.init(keyManagers, trustManagers, null);
             } catch (KeyManagementException e) {
-                e.printStackTrace();
+                LOG.error("Error initializing SSLContext", e);
             }
             return sslContext;
         }


### PR DESCRIPTION
## Changes

### MLE-26858 — Incorrect Bitwise Shift of Integer  
- File: Decoder.java —` _decodeUnsigned()` and `decodeUnsigned(int n)`

- Issue: When the shift amount `(nbits or n) is ≥ 64`, Java applies modulo 64 to shift operations. This makes `reg >>>= 64` behave as` reg >>>= 0`, so no bits are shifted out and stale data remains in the register.

- The masking logic already handled this correctly using a conditional check on `nbits`, but the shift operation did not.

- Fix: Added explicit guard for large shift values by zeroing the register when `nbits ≥ 64`, otherwise performing the shift normally.

---

### MLE-26901 — Bad Use of Null-like Value (Remove unused constructors)
- Files: ContentWriter.java, DatabaseContentWriter.java

- Issue: The 3-argument constructors passed null for `AssignmentManager` when delegating to the 4-argument constructor. The 4-argument constructor immediately dereferenced this value by calling `am.getEffectiveVersion()`, resulting in a guaranteed `NullPointerException` if the 3-argument constructor was ever used.

- Fix: Removed both unused and unsafe 3-argument constructors. Verified that all call sites already use the 4-argument constructor with a valid `AssignmentManager` instance, so no functional impact.

---

### MLE-26837 — Insufficient Logging  
- File: ContentReader.java — `SslOptions.getSslContext()`

- Issue: Security exceptions (`NoSuchAlgorithmException`, `KeyManagementException`) were handled using `e.printStackTrace()`, which is unreliable in Hadoop environments since stderr logs may not be captured.

- Fix: Replaced `printStackTrace` usage with structured logging using the existing logger. Ensured errors during `SSLContext` creation and initialization are properly logged. Added missing logger instance to `SslOptions` consistent with project conventions.

---

### Tests
- Ran unit tests → All passed
- Ran 06mlcp test suite → No regression failures were found