### PR TITLE
MLE-29171 MLE-29170 MLE-29172: Fix Polaris bitwise shift, null-like Value, and insufficient logging (BackPort)

### DIFF
--- a/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,11 +71,6 @@ public class DatabaseContentWriter<VALUE> extends
     public static final String XQUERY_VERSION_1_0_ML = 
             "xquery version \"1.0-ml\";\n";
 
-    public DatabaseContentWriter(Configuration conf,
-        Map<String, ContentSource> hostSourceMap, boolean fastLoad) {
-        this(conf, hostSourceMap, fastLoad, null); 
-    }
-    
     public DatabaseContentWriter(Configuration conf,
             Map<String, ContentSource> hostSourceMap, boolean fastLoad,
             AssignmentManager am) {

--- a/src/main/java/com/marklogic/io/Decoder.java
+++ b/src/main/java/com/marklogic/io/Decoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,11 @@ public class Decoder {
         long val = reg & ((nbits < 64) ? ((1L << nbits) - 1) : -1L);
         for (int i = 0; i < nbits; i += 4)
             val += (1L << i);
-        reg >>>= nbits;
+        if (nbits >= 64) {
+            reg = 0;
+        } else {
+            reg >>>= nbits;
+        }
         numBitsInReg -= nbits;
         return (int)(val & 0xffffffffL);
     }
@@ -182,7 +186,11 @@ public class Decoder {
         if (n > numBitsInReg)
             load();
         long v = reg & ((n < 64) ? ((1L << n) - 1) : -1L);
-        reg >>>= n;
+        if (n >= 64) {
+            reg = 0;
+        } else {
+            reg >>>= n;
+        }
         numBitsInReg -= n;
         return (int)(v & 0xffffffffL);
     }

--- a/src/main/java/com/marklogic/mapreduce/ContentWriter.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,11 +198,6 @@ implements MarkLogicConstants {
 
     protected final int MAX_SLEEP_TIME = 120000;
 
-    
-    public ContentWriter(Configuration conf, 
-        Map<String, ContentSource> hostSourceMap, boolean fastLoad) {
-        this(conf, hostSourceMap, fastLoad, null);
-    }
     
     public ContentWriter(Configuration conf,
         Map<String, ContentSource> hostSourceMap, boolean fastLoad,

--- a/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
+++ b/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,9 @@ public class ContentReader {
     }
     
     static class SslOptions implements SslConfigOptions {
+        public static final Log LOG =
+            LogFactory.getLog(SslOptions.class);
+
         @Override
         public String[] getEnabledCipherSuites() {
             return null;
@@ -111,7 +114,7 @@ public class ContentReader {
             try {
                 sslContext = SSLContext.getInstance("TLSv1.3");
             } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
+                LOG.error("Error creating SSLContext", e);
             }
             TrustManager[] trustManagers = null;
             // Trust anyone.
@@ -135,7 +138,7 @@ public class ContentReader {
             try {
                 sslContext.init(keyManagers, trustManagers, null);
             } catch (KeyManagementException e) {
-                e.printStackTrace();
+                LOG.error("Error initializing SSLContext", e);
             }
             return sslContext;
         }


### PR DESCRIPTION
These changes have already been validated on the develop branch in the PR:  https://github.com/marklogic/marklogic-contentpump/pull/598

### Tests
- Ran unit tests → All passed
- Ran 06mlcp test suite → No regression failures were found