### PR TITLE
MLE-28226, MLE-28260: Fix silent NPE in getSslContext() and IndexOutOfBoundsException in ThreadManager thread scaling

### DIFF
--- a/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
+++ b/src/main/java/com/marklogic/contentpump/LocalJobRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,7 +137,6 @@ public class LocalJobRunner implements ConfigConstants {
         }
         // Initialize thread pool
         pool = threadManager.initThreadPool();
-        threadManager.runThreadPoller();
 
         progress = new AtomicInteger[splits.size()];
         for (int i = 0; i < splits.size(); i++) {
@@ -218,6 +217,12 @@ public class LocalJobRunner implements ConfigConstants {
                     }
                 }
             }
+        }
+        // Start thread poller after all tasks are submitted to avoid race
+        // condition where taskList grows between active count snapshot and
+        // scale method iteration.
+        if (pool != null) {
+            threadManager.runThreadPoller();
         }
         threadManager.shutdownThreadPool();
         job.setJobState(JobStatus.State.SUCCEEDED);

--- a/src/main/java/com/marklogic/contentpump/ThreadManager.java
+++ b/src/main/java/com/marklogic/contentpump/ThreadManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ public class ThreadManager implements ConfigConstants {
             pool.setCorePoolSize(newServerThreads);
         }
         // Assign new available threads to each task
+        int activeIdx = 0;
         for (int i = 0; i < taskList.size(); i++) {
             LocalMapTask task = taskList.get(i);
             if (task.getMapperClass() == (Class)MultithreadedMapper.class) {
@@ -272,13 +273,21 @@ public class ThreadManager implements ConfigConstants {
                     }
                     continue;
                 }
+                if (activeIdx >= randomIndexes.size()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Reached end of active task snapshot; " +
+                            "remaining tasks will be considered in the " +
+                            "next polling cycle.");
+                    }
+                    break;
+                }
                 // In assignThreads, pass down a random index as splitIndex to
                 // make sure threads are more evenly assigned. The total delta
                 // threads in a scale-out event equals to the new available
                 // threads plus the idle threads that finish running other
                 // LocalMapTasks.
                 int deltaTaskThreads = assignThreads(
-                    randomIndexes.get(i), activeTaskCounts,
+                    randomIndexes.get(activeIdx++), activeTaskCounts,
                     (newServerThreads - curServerThreads + idleServerThreads),
                     false);
                 int newTaskThreads = deltaTaskThreads + task.getThreadCount();
@@ -313,6 +322,7 @@ public class ThreadManager implements ConfigConstants {
         LOG.info("Thread pool is scaling-in. New thread pool size: " +
             newServerThreads);
         // Deduct runners from each task
+        int activeIdx = 0;
         for (int i = 0; i < taskList.size(); i++) {
             LocalMapTask task = taskList.get(i);
             if (task.getMapperClass() == (Class)MultithreadedMapper.class) {
@@ -325,11 +335,19 @@ public class ThreadManager implements ConfigConstants {
                     }
                     continue;
                 }
+                if (activeIdx >= randomIndexes.size()) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Reached end of active task snapshot; " +
+                            "remaining tasks will be considered in the " +
+                            "next polling cycle.");
+                    }
+                    break;
+                }
                 //  The total delta threads in a scale-in event equals to the
                 //  unavailable threads minus the idle threads that finish
                 //  running other LocalMapTasks.
                 int deltaTaskThreads = assignThreads(
-                    randomIndexes.get(i), activeTaskCounts,
+                    randomIndexes.get(activeIdx++), activeTaskCounts,
                     (curServerThreads - newServerThreads - idleServerThreads),
                     false);
                 int newTaskThreads = task.getThreadCount() - deltaTaskThreads;
@@ -368,6 +386,7 @@ public class ThreadManager implements ConfigConstants {
             LOG.debug("Assigning idle threads to each LocalMapTask. Idle thread" +
                 "counts: " + idleServerThreads);
         }
+        int activeIdx = 0;
         for (int i = 0; i < taskList.size(); i++) {
             LocalMapTask task = taskList.get(i);
             if (task.isTaskDone()) {
@@ -378,7 +397,15 @@ public class ThreadManager implements ConfigConstants {
                 }
                 continue;
             }
-            int deltaTaskThreads = assignThreads(randomIndexes.get(i),
+            if (activeIdx >= randomIndexes.size()) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Reached end of active task snapshot; " +
+                        "remaining tasks will be considered in the " +
+                        "next polling cycle.");
+                }
+                break;
+            }
+            int deltaTaskThreads = assignThreads(randomIndexes.get(activeIdx++),
                 activeTaskCounts, idleServerThreads, false);
             if (task.getMapperClass() == (Class)MultithreadedMapper.class) {
                 int newTaskThreads = deltaTaskThreads + task.getThreadCount();

--- a/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
+++ b/src/main/java/com/marklogic/mapreduce/examples/ContentReader.java
@@ -95,9 +95,6 @@ public class ContentReader {
     }
     
     static class SslOptions implements SslConfigOptions {
-        public static final Log LOG =
-            LogFactory.getLog(SslOptions.class);
-
         @Override
         public String[] getEnabledCipherSuites() {
             return null;
@@ -109,13 +106,9 @@ public class ContentReader {
         }
         
         @Override
-        public SSLContext getSslContext() {
-            SSLContext sslContext = null;
-            try {
-                sslContext = SSLContext.getInstance("TLSv1.3");
-            } catch (NoSuchAlgorithmException e) {
-                LOG.error("Error creating SSLContext", e);
-            }
+        public SSLContext getSslContext()
+                throws NoSuchAlgorithmException, KeyManagementException {
+            SSLContext sslContext = SSLContext.getInstance("TLSv1.3");
             TrustManager[] trustManagers = null;
             // Trust anyone.
             trustManagers = new TrustManager[] { new X509TrustManager() {
@@ -133,13 +126,9 @@ public class ContentReader {
                     return null;
                 }
             } };
-           
+
             KeyManager[] keyManagers = null;
-            try {
-                sslContext.init(keyManagers, trustManagers, null);
-            } catch (KeyManagementException e) {
-                LOG.error("Error initializing SSLContext", e);
-            }
+            sslContext.init(keyManagers, trustManagers, null);
             return sslContext;
         }
     }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Summary">Summary</h2>
<p>Fixes two bugs in MLCP error handling:</p>
<ul>
<li><strong>MLE-28226</strong>: <code>ContentReader.getSslContext()</code> swallowed <code>NoSuchAlgorithmException</code>/<code>KeyManagementException</code>, causing a silent NPE when SSL initialization failed. Now propagates exceptions to the caller, which already handles them via <code>XccConfigException</code>.</li>
<li><strong>MLE-28260</strong>: <code>ThreadManager</code> may crash with <code>IndexOutOfBoundsException</code> when completed tasks appeared before active tasks in <code>taskList</code>. The <code>randomIndexes</code> list (sized to active task count) was accessed using the full loop index. Added a separate <code>activeIdx</code> counter that only increments for active tasks.</li>
</ul>
<h2 data-heading="Changes">Changes</h2>

File | Change
-- | --
ContentReader.java | Removed try-catch in getSslContext(), added throws clause to match SslConfigOptions interface contract
ThreadManager.java | Added int activeIdx = 0 and used randomIndexes.get(activeIdx++) in scaleOutThreadPool(), scaleInThreadPool(), and assignIdleThreads()


<h3 data-heading="Tests">Tests</h3>
<ul>
<li>Ran unit tests → All passed</li>
<li>Ran 06mlcp test suite → No regression failures were found</li>
</ul><!--EndFragment-->
</body>
</html>