### PR TITLE
MLE-26902: Fix bad use of null-like value and insufficient logging

### DIFF
--- a/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
+++ b/src/main/java/com/marklogic/contentpump/DatabaseContentReader.java
@@ -499,6 +499,9 @@ public class DatabaseContentReader extends
         metadata.setPermString(buf.toString());
         
         // handle quality, always present even if not requested (barrier)
+        if (item == null) {
+            throw new IOException("Unexpected null item when reading quality");
+        }
         metadata.setQuality((XSInteger) item.getItem());
         
         // handle metadata
@@ -625,7 +628,7 @@ public class DatabaseContentReader extends
                         queryNakedProperties();
                         int curCount = 0;
                         while (curCount < nakedCount) {
-                            if (result.hasNext()) {
+                            if (result != null && result.hasNext()) {
                                 result.next();
                                 curCount++;
                             } else { 
@@ -634,7 +637,7 @@ public class DatabaseContentReader extends
                         }
                     }
                
-                    if (result.hasNext()) {
+                    if (result != null && result.hasNext()) {
                         ResultItem currItem = null;
                         currItem = result.next();
 

--- a/src/main/java/com/marklogic/contentpump/OutputArchive.java
+++ b/src/main/java/com/marklogic/contentpump/OutputArchive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2020 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,8 +133,9 @@ public class OutputArchive implements InternalConstants {
             boolean isExportDoc) 
     throws IOException {
         ZipEntry entry = new ZipEntry(uri);
-        if (outputStream == null || 
-            (currentFileBytes + size > Integer.MAX_VALUE) &&
+        if (outputStream == null) {
+            newOutputStream();
+        } else if ((currentFileBytes + size > Integer.MAX_VALUE) &&
              currentFileBytes > 0) {
             if (currentEntries % 2 == 0 && !isExportDoc) {
                 //the file overflowed is metadata, create new zip

--- a/src/main/java/com/marklogic/mapreduce/DatabaseDocument.java
+++ b/src/main/java/com/marklogic/mapreduce/DatabaseDocument.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,13 +75,17 @@ InternalConstants {
      */
     public byte[] getContentAsByteArray() {
         if (content == null) {
-            try {
-                content = IOHelper.byteArrayFromStream(is);
-            } catch (IOException e) {
-                throw new RuntimeException("IOException buffering binary data",
-                        e);
+            if (is != null) {
+                try {
+                    content = IOHelper.byteArrayFromStream(is);
+                } catch (IOException e) {
+                    throw new RuntimeException("IOException buffering binary data",
+                            e);
+                }
+                is = null;
+            } else {
+                content = new byte[0];
             }
-            is = null;
         }
         return content;
     }

--- a/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,7 +223,9 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
                 throw new IOException("Unexpected item " + item.getItemType().toString());
             }
             String itemStr = ((XSString)item.getItem()).asString();
-            ruleUris.add(itemStr);
+            if (ruleUris != null) {
+                ruleUris.add(itemStr);
+            }
         }
 
         // forest with failover hosts

--- a/src/main/java/com/marklogic/mapreduce/utilities/InternalUtilities.java
+++ b/src/main/java/com/marklogic/mapreduce/utilities/InternalUtilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +364,7 @@ public class InternalUtilities implements MarkLogicConstants {
         try {
             options = new SecurityOptions(sslOptions.getSslContext());
         } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            LOG.error("Error constructing SecurityOptions", e);
             throw new XccConfigException("Error constructing SecurityOptions",
                     e);
         }


### PR DESCRIPTION

## Changes

### OutputArchive.java

* **Issue**:
  The condition combined `outputStream == null` with file overflow checks.
  When `outputStream` was `null` but the inner condition was false (e.g., odd entry or export doc), `newOutputStream()` was not called, leading to an NPE at `putNextEntry()`.

* **Fix**:
  Separated the null check so `newOutputStream()` is always called when `outputStream` is `null`.

---

### DatabaseDocument.java

* **Issue**:
  `getContentAsByteArray()` passed `is` directly to `IOHelper.byteArrayFromStream()` without checking for `null`.
  Only `IOException` was caught, resulting in an uncaught NPE.

* **Fix**:
  Added `is != null` guard before invocation.
  If both `content` and `is` are `null`, `content` is initialized to `new byte[0]` and cached (consistent with existing behavior).

---

### DatabaseContentReader.java

* **Issues**:

  1. `item` could become `null` in loops, but `item.getItem()` was still called afterward.
  2. `result.hasNext()` was called without checking if `result` was `null`.

* **Fixes**:

  * Added explicit null check on `item` with a descriptive `IOException`.
  * Updated conditions to:

    ```java
    result != null && result.hasNext()
    ```

---

### MarkLogicInputFormat.java

* **Issue**:
  `ruleUris` may be `null` when no redaction rules are configured, yet `getForestSplits()` called `ruleUris.add()`.


* **Fix**:
  Added defensive guard:

  ```java
  if (ruleUris != null)
  ```

---

### InternalUtilities.java

* **Issue**:
  `KeyManagementException` and `NoSuchAlgorithmException` were wrapped and rethrown without logging, hiding security-related failures.

* **Fix**:
  Added error logging before rethrow:

  ```java
  LOG.error("Error constructing SecurityOptions", e);
  ```

---

## Files Changed

* `src/main/java/com/marklogic/contentpump/DatabaseContentReader.java`
* `src/main/java/com/marklogic/contentpump/OutputArchive.java`
* `src/main/java/com/marklogic/mapreduce/DatabaseDocument.java`
* `src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java`
* `src/main/java/com/marklogic/mapreduce/utilities/InternalUtilities.java`

---

## Testing

- Ran unit tests → All passed
- Ran 06mlcp test suite → No regression failures were found
