### PR TITLE
MLE-28100 MLE-29561: fix ResourceSequence leak in ContentOutputFormat initialize() and null pointer dereference in NodeImpl.isEqualNode()

### DIFF
--- a/src/main/java/com/marklogic/dom/NodeImpl.java
+++ b/src/main/java/com/marklogic/dom/NodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -329,22 +329,22 @@ public abstract class NodeImpl implements Node {
             return false;
         if (hasAttributes() != other.hasAttributes())
             return false;
-        if (hasChildNodes()) {
+        if (hasAttributes()) {
             NamedNodeMap thisAttr = getAttributes();
             NamedNodeMap otherAttr = other.getAttributes();
             if (thisAttr.getLength() != otherAttr.getLength())
                 return false;
             for (int i = 0; i < thisAttr.getLength(); i++)
-                if (thisAttr.item(i).isEqualNode(otherAttr.item(i)))
+                if (!thisAttr.item(i).isEqualNode(otherAttr.item(i)))
                     return false;
         }
-        if (hasAttributes()) {
+        if (hasChildNodes()) {
             NodeList thisChild = getChildNodes();
             NodeList otherChild = other.getChildNodes();
             if (thisChild.getLength() != otherChild.getLength())
                 return false;
             for (int i = 0; i < thisChild.getLength(); i++)
-                if (thisChild.item(i).isEqualNode(otherChild.item(i)))
+                if (!thisChild.item(i).isEqualNode(otherChild.item(i)))
                     return false;
         }
         return true;

--- a/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2024 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -404,114 +404,120 @@ public class ContentOutputFormat<VALUEOUT> extends
         if (LOG.isDebugEnabled()) {
             LOG.debug("init query: \n" + query.getQuery());
         }
-        result = session.submitRequest(query);
+        try {
+            result = session.submitRequest(query);
 
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        ResultItem item = result.next();
-        boolean httpForwardHeaderExists;
-        boolean xdbcForwardHeaderExists;
-        if (getForwardHeader) {
-            httpForwardHeaderExists = item.asString().equals("true");
             if (!result.hasNext()) {
                 throw new IOException("Unexpected response");
             }
-            item = result.next();
-            xdbcForwardHeaderExists = item.asString().equals("true");
-            if (!result.hasNext()) {
-                throw new IOException("Unexpected response");
-            }
-            item = result.next();
-            if (httpForwardHeaderExists || xdbcForwardHeaderExists) {
-                restrictHosts = true;
-                conf.setBoolean(OUTPUT_RESTRICT_HOSTS, true);
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("HTTP compliant mode enabled since x-forwarded-for exists");
+            ResultItem item = result.next();
+            boolean httpForwardHeaderExists;
+            boolean xdbcForwardHeaderExists;
+            if (getForwardHeader) {
+                httpForwardHeaderExists = item.asString().equals("true");
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
                 }
-            } else {
-                // check if input needs to be in HTTP compliant mode
-                String inputRestrictHost = conf.getTrimmed(INPUT_RESTRICT_HOSTS);
-                if (inputRestrictHost == null || 
-                    inputRestrictHost.equalsIgnoreCase("false")) {
-                    HttpChannel.setUseHTTP(false);
+                item = result.next();
+                xdbcForwardHeaderExists = item.asString().equals("true");
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
+                }
+                item = result.next();
+                if (httpForwardHeaderExists || xdbcForwardHeaderExists) {
+                    restrictHosts = true;
+                    conf.setBoolean(OUTPUT_RESTRICT_HOSTS, true);
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("HTTP compliant mode disabled since x-forwarded-for doesn't exist");
+                        LOG.debug("HTTP compliant mode enabled since x-forwarded-for exists");
+                    }
+                } else {
+                    // check if input needs to be in HTTP compliant mode
+                    String inputRestrictHost = conf.getTrimmed(INPUT_RESTRICT_HOSTS);
+                    if (inputRestrictHost == null || 
+                        inputRestrictHost.equalsIgnoreCase("false")) {
+                        HttpChannel.setUseHTTP(false);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("HTTP compliant mode disabled since x-forwarded-for doesn't exist");
+                        }
                     }
                 }
             }
-        }
-        initHostName = item.asString();
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        am.setEffectiveVersion(((XSInteger)item.getItem()).asLong());
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        failover = !restrictHosts && item.asString().equals("true");
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        supportSegment = item.asString().equals("true");
-        if (result.hasNext()) {
-            item = result.next();
-            String policyStr = item.asString();
-            conf.set(ASSIGNMENT_POLICY, policyStr);
-            policy = AssignmentPolicy.Kind.forName(policyStr);
+            initHostName = item.asString();
             if (!result.hasNext()) {
                 throw new IOException("Unexpected response");
             }
             item = result.next();
-            allowFastLoad = Boolean.parseBoolean(item.asString());
-            if ((policy == AssignmentPolicy.Kind.STATISTICAL 
-                || policy == AssignmentPolicy.Kind.RANGE
-                || policy == AssignmentPolicy.Kind.QUERY)
-                && !allowFastLoad && conf.getBoolean(OUTPUT_FAST_LOAD, false)) {
-                throw new IOException(
-                    "Fastload can't be used: rebalancer is on and "
-                        + "forests are imbalanced in a database with "
-                        + "statistics-based assignment policy");
+            am.setEffectiveVersion(((XSInteger)item.getItem()).asLong());
+            if (!result.hasNext()) {
+                throw new IOException("Unexpected response");
             }
-        } else {
-        	policy = AssignmentPolicy.Kind.LEGACY;
-        	legacy = true;
-        }
-        
-        // initialize fastload mode
-        if (conf.get(OUTPUT_FAST_LOAD) == null) {
-            // fastload not set
-            if (conf.get(OUTPUT_DIRECTORY) != null) {
-                // output_dir is set, attempt to do fastload
-                if(conf.get(OUTPUT_PARTITION) == null && 
-                   (policy == AssignmentPolicy.Kind.RANGE ||
-                    policy == AssignmentPolicy.Kind.QUERY)) {
-                    fastLoad = false;
-                } else if (policy == AssignmentPolicy.Kind.RANGE ||
-                           policy == AssignmentPolicy.Kind.QUERY ||
-                	   policy == AssignmentPolicy.Kind.STATISTICAL) {
-                    fastLoad = allowFastLoad;
-                } else {
-                	fastLoad = true;
+            item = result.next();
+            failover = !restrictHosts && item.asString().equals("true");
+            if (!result.hasNext()) {
+                throw new IOException("Unexpected response");
+            }
+            item = result.next();
+            supportSegment = item.asString().equals("true");
+            if (result.hasNext()) {
+                item = result.next();
+                String policyStr = item.asString();
+                conf.set(ASSIGNMENT_POLICY, policyStr);
+                policy = AssignmentPolicy.Kind.forName(policyStr);
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
+                }
+                item = result.next();
+                allowFastLoad = Boolean.parseBoolean(item.asString());
+                if ((policy == AssignmentPolicy.Kind.STATISTICAL 
+                    || policy == AssignmentPolicy.Kind.RANGE
+                    || policy == AssignmentPolicy.Kind.QUERY)
+                    && !allowFastLoad && conf.getBoolean(OUTPUT_FAST_LOAD, false)) {
+                    throw new IOException(
+                        "Fastload can't be used: rebalancer is on and "
+                            + "forests are imbalanced in a database with "
+                            + "statistics-based assignment policy");
                 }
             } else {
-                //neither fastload nor output_dir is set
-                fastLoad = false;
+            	policy = AssignmentPolicy.Kind.LEGACY;
+            	legacy = true;
             }
-        } else {
-            fastLoad = conf.getBoolean(OUTPUT_FAST_LOAD, false);
-            if (fastLoad && conf.get(OUTPUT_PARTITION) == null
-                && (policy == AssignmentPolicy.Kind.RANGE ||
-                    policy == AssignmentPolicy.Kind.QUERY)) {
-                throw new IllegalArgumentException(
-                    "output_partition is required for fastload mode.");
+            
+            // initialize fastload mode
+            if (conf.get(OUTPUT_FAST_LOAD) == null) {
+                // fastload not set
+                if (conf.get(OUTPUT_DIRECTORY) != null) {
+                    // output_dir is set, attempt to do fastload
+                    if(conf.get(OUTPUT_PARTITION) == null && 
+                       (policy == AssignmentPolicy.Kind.RANGE ||
+                        policy == AssignmentPolicy.Kind.QUERY)) {
+                        fastLoad = false;
+                    } else if (policy == AssignmentPolicy.Kind.RANGE ||
+                               policy == AssignmentPolicy.Kind.QUERY ||
+                    	   policy == AssignmentPolicy.Kind.STATISTICAL) {
+                        fastLoad = allowFastLoad;
+                    } else {
+                    	fastLoad = true;
+                    }
+                } else {
+                    //neither fastload nor output_dir is set
+                    fastLoad = false;
+                }
+            } else {
+                fastLoad = conf.getBoolean(OUTPUT_FAST_LOAD, false);
+                if (fastLoad && conf.get(OUTPUT_PARTITION) == null
+                    && (policy == AssignmentPolicy.Kind.RANGE ||
+                        policy == AssignmentPolicy.Kind.QUERY)) {
+                    throw new IllegalArgumentException(
+                        "output_partition is required for fastload mode.");
+                }
+            }
+            conf.setBoolean(OUTPUT_FAST_LOAD, fastLoad);
+            return restrictHosts;
+        } finally {
+            if (result != null) {
+                result.close();
             }
         }
-        conf.setBoolean(OUTPUT_FAST_LOAD, fastLoad);
-        return restrictHosts;
     }
 
     /**


### PR DESCRIPTION
 ### MLE-28100 — Fix `ResultSequence` leak in `ContentOutputFormat.initialize()`

  Problem:
  - `initialize()` called `session.submitRequest(query)` and stored the result in a `ResultSequence`, but never closed it. On repeated initializations or exception paths, this leaked server-side connections and sockets.

  Fix:
  - Wrapped the `submitRequest` call and result-reading logic in a try/finally block that calls `result.close()`.

  File: src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java

  ----------

  ### MLE-29561 — Fix NULL pointer dereference and logic bugs in `NodeImpl.isEqualNode()`

  Problem:
  Three logic bugs in `isEqualNode()`:

   1. The `hasChildNodes() `guard was used to enter the attributes comparison block — `getAttributes()` could return null if the node has no attributes, causing a NPE.
   2. The `hasAttributes()` guard was used to enter the child nodes comparison block — incorrect semantics.
   3. Both `isEqualNode()` comparisons were missing negation — the method returned false when nodes were equal instead of when they were not equal.

  Fix:

   - Swapped `hasAttributes() / hasChildNodes()` guards to match their respective blocks.
   - Added ! negation to both `isEqualNode()` comparisons.

  File: src/main/java/com/marklogic/dom/NodeImpl.java

---

### Tests
- Ran unit tests → All passed
- Ran 06mlcp test suite → No regression failures were found