### PR TITLE
MLE-29898 MLE-29899: [develop-11.3] fix ResourceSequence leak in ContentOutputFormat initialize() and null pointer dereference in NodeImpl.isEqualNode() (Backport)

### DIFF
--- a/src/main/java/com/marklogic/dom/NodeImpl.java
+++ b/src/main/java/com/marklogic/dom/NodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -329,22 +329,22 @@ public abstract class NodeImpl implements Node {
             return false;
         if (hasAttributes() != other.hasAttributes())
             return false;
-        if (hasChildNodes()) {
+        if (hasAttributes()) {
             NamedNodeMap thisAttr = getAttributes();
             NamedNodeMap otherAttr = other.getAttributes();
             if (thisAttr.getLength() != otherAttr.getLength())
                 return false;
             for (int i = 0; i < thisAttr.getLength(); i++)
-                if (thisAttr.item(i).isEqualNode(otherAttr.item(i)))
+                if (!thisAttr.item(i).isEqualNode(otherAttr.item(i)))
                     return false;
         }
-        if (hasAttributes()) {
+        if (hasChildNodes()) {
             NodeList thisChild = getChildNodes();
             NodeList otherChild = other.getChildNodes();
             if (thisChild.getLength() != otherChild.getLength())
                 return false;
             for (int i = 0; i < thisChild.getLength(); i++)
-                if (thisChild.item(i).isEqualNode(otherChild.item(i)))
+                if (!thisChild.item(i).isEqualNode(otherChild.item(i)))
                     return false;
         }
         return true;

--- a/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
+ * Copyright (c) 2011-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,114 +400,120 @@ public class ContentOutputFormat<VALUEOUT> extends
         if (LOG.isDebugEnabled()) {
             LOG.debug("init query: \n" + query.getQuery());
         }
-        result = session.submitRequest(query);
+        try {
+            result = session.submitRequest(query);
 
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        ResultItem item = result.next();
-        boolean httpForwardHeaderExists;
-        boolean xdbcForwardHeaderExists;
-        if (getForwardHeader) {
-            httpForwardHeaderExists = item.asString().equals("true");
             if (!result.hasNext()) {
                 throw new IOException("Unexpected response");
             }
-            item = result.next();
-            xdbcForwardHeaderExists = item.asString().equals("true");
-            if (!result.hasNext()) {
-                throw new IOException("Unexpected response");
-            }
-            item = result.next();
-            if (httpForwardHeaderExists || xdbcForwardHeaderExists) {
-                restrictHosts = true;
-                conf.setBoolean(OUTPUT_RESTRICT_HOSTS, true);
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("HTTP compliant mode enabled since x-forwarded-for exists");
+            ResultItem item = result.next();
+            boolean httpForwardHeaderExists;
+            boolean xdbcForwardHeaderExists;
+            if (getForwardHeader) {
+                httpForwardHeaderExists = item.asString().equals("true");
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
                 }
-            } else {
-                // check if input needs to be in HTTP compliant mode
-                String inputRestrictHost = conf.getTrimmed(INPUT_RESTRICT_HOSTS);
-                if (inputRestrictHost == null || 
-                    inputRestrictHost.equalsIgnoreCase("false")) {
-                    HttpChannel.setUseHTTP(false);
+                item = result.next();
+                xdbcForwardHeaderExists = item.asString().equals("true");
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
+                }
+                item = result.next();
+                if (httpForwardHeaderExists || xdbcForwardHeaderExists) {
+                    restrictHosts = true;
+                    conf.setBoolean(OUTPUT_RESTRICT_HOSTS, true);
                     if (LOG.isDebugEnabled()) {
-                        LOG.debug("HTTP compliant mode disabled since x-forwarded-for doesn't exist");
+                        LOG.debug("HTTP compliant mode enabled since x-forwarded-for exists");
+                    }
+                } else {
+                    // check if input needs to be in HTTP compliant mode
+                    String inputRestrictHost = conf.getTrimmed(INPUT_RESTRICT_HOSTS);
+                    if (inputRestrictHost == null || 
+                        inputRestrictHost.equalsIgnoreCase("false")) {
+                        HttpChannel.setUseHTTP(false);
+                        if (LOG.isDebugEnabled()) {
+                            LOG.debug("HTTP compliant mode disabled since x-forwarded-for doesn't exist");
+                        }
                     }
                 }
             }
-        }
-        initHostName = item.asString();
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        am.setEffectiveVersion(((XSInteger)item.getItem()).asLong());
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        failover = !restrictHosts && item.asString().equals("true");
-        if (!result.hasNext()) {
-            throw new IOException("Unexpected response");
-        }
-        item = result.next();
-        supportSegment = item.asString().equals("true");
-        if (result.hasNext()) {
-            item = result.next();
-            String policyStr = item.asString();
-            conf.set(ASSIGNMENT_POLICY, policyStr);
-            policy = AssignmentPolicy.Kind.forName(policyStr);
+            initHostName = item.asString();
             if (!result.hasNext()) {
                 throw new IOException("Unexpected response");
             }
             item = result.next();
-            allowFastLoad = Boolean.parseBoolean(item.asString());
-            if ((policy == AssignmentPolicy.Kind.STATISTICAL 
-                || policy == AssignmentPolicy.Kind.RANGE
-                || policy == AssignmentPolicy.Kind.QUERY)
-                && !allowFastLoad && conf.getBoolean(OUTPUT_FAST_LOAD, false)) {
-                throw new IOException(
-                    "Fastload can't be used: rebalancer is on and "
-                        + "forests are imbalanced in a database with "
-                        + "statistics-based assignment policy");
+            am.setEffectiveVersion(((XSInteger)item.getItem()).asLong());
+            if (!result.hasNext()) {
+                throw new IOException("Unexpected response");
             }
-        } else {
-        	policy = AssignmentPolicy.Kind.LEGACY;
-        	legacy = true;
-        }
-        
-        // initialize fastload mode
-        if (conf.get(OUTPUT_FAST_LOAD) == null) {
-            // fastload not set
-            if (conf.get(OUTPUT_DIRECTORY) != null) {
-                // output_dir is set, attempt to do fastload
-                if(conf.get(OUTPUT_PARTITION) == null && 
-                   (policy == AssignmentPolicy.Kind.RANGE ||
-                    policy == AssignmentPolicy.Kind.QUERY)) {
-                    fastLoad = false;
-                } else if (policy == AssignmentPolicy.Kind.RANGE ||
-                           policy == AssignmentPolicy.Kind.QUERY ||
-                	   policy == AssignmentPolicy.Kind.STATISTICAL) {
-                    fastLoad = allowFastLoad;
-                } else {
-                	fastLoad = true;
+            item = result.next();
+            failover = !restrictHosts && item.asString().equals("true");
+            if (!result.hasNext()) {
+                throw new IOException("Unexpected response");
+            }
+            item = result.next();
+            supportSegment = item.asString().equals("true");
+            if (result.hasNext()) {
+                item = result.next();
+                String policyStr = item.asString();
+                conf.set(ASSIGNMENT_POLICY, policyStr);
+                policy = AssignmentPolicy.Kind.forName(policyStr);
+                if (!result.hasNext()) {
+                    throw new IOException("Unexpected response");
+                }
+                item = result.next();
+                allowFastLoad = Boolean.parseBoolean(item.asString());
+                if ((policy == AssignmentPolicy.Kind.STATISTICAL 
+                    || policy == AssignmentPolicy.Kind.RANGE
+                    || policy == AssignmentPolicy.Kind.QUERY)
+                    && !allowFastLoad && conf.getBoolean(OUTPUT_FAST_LOAD, false)) {
+                    throw new IOException(
+                        "Fastload can't be used: rebalancer is on and "
+                            + "forests are imbalanced in a database with "
+                            + "statistics-based assignment policy");
                 }
             } else {
-                //neither fastload nor output_dir is set
-                fastLoad = false;
+            	policy = AssignmentPolicy.Kind.LEGACY;
+            	legacy = true;
             }
-        } else {
-            fastLoad = conf.getBoolean(OUTPUT_FAST_LOAD, false);
-            if (fastLoad && conf.get(OUTPUT_PARTITION) == null
-                && (policy == AssignmentPolicy.Kind.RANGE ||
-                    policy == AssignmentPolicy.Kind.QUERY)) {
-                throw new IllegalArgumentException(
-                    "output_partition is required for fastload mode.");
+            
+            // initialize fastload mode
+            if (conf.get(OUTPUT_FAST_LOAD) == null) {
+                // fastload not set
+                if (conf.get(OUTPUT_DIRECTORY) != null) {
+                    // output_dir is set, attempt to do fastload
+                    if(conf.get(OUTPUT_PARTITION) == null && 
+                       (policy == AssignmentPolicy.Kind.RANGE ||
+                        policy == AssignmentPolicy.Kind.QUERY)) {
+                        fastLoad = false;
+                    } else if (policy == AssignmentPolicy.Kind.RANGE ||
+                               policy == AssignmentPolicy.Kind.QUERY ||
+                    	   policy == AssignmentPolicy.Kind.STATISTICAL) {
+                        fastLoad = allowFastLoad;
+                    } else {
+                    	fastLoad = true;
+                    }
+                } else {
+                    //neither fastload nor output_dir is set
+                    fastLoad = false;
+                }
+            } else {
+                fastLoad = conf.getBoolean(OUTPUT_FAST_LOAD, false);
+                if (fastLoad && conf.get(OUTPUT_PARTITION) == null
+                    && (policy == AssignmentPolicy.Kind.RANGE ||
+                        policy == AssignmentPolicy.Kind.QUERY)) {
+                    throw new IllegalArgumentException(
+                        "output_partition is required for fastload mode.");
+                }
+            }
+            conf.setBoolean(OUTPUT_FAST_LOAD, fastLoad);
+            return restrictHosts;
+        } finally {
+            if (result != null) {
+                result.close();
             }
         }
-        conf.setBoolean(OUTPUT_FAST_LOAD, fastLoad);
-        return restrictHosts;
     }
 
     /**


### PR DESCRIPTION
These changes have already been validated on the develop branch in the PR: #605 

### Tests
- Ran unit tests → All passed
- Ran 06mlcp test suite → No regression failures were found