### PR TITLE
MLE-30494: Support isolated HTTP and XDBC requests

### DIFF
--- a/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/ContentOutputFormat.java
@@ -128,13 +128,18 @@ public class ContentOutputFormat<VALUEOUT> extends
       + "return if (exists($f)) then $f() else ()";
     // For HTTP Server
     public static final String HEADER_QUERY =
-        "fn:exists(xdmp:get-request-header('x-forwarded-for'))";
+        "let $f := fn:function-lookup(xs:QName('xdmp:is-forwarded'),0)\n" +
+        "return if (exists($f)) then $f() " +
+        "else fn:exists(xdmp:get-request-header('x-forwarded-for'))";
     // For XDBC Server
     public static final String XDBC_HEADER_QUERY =
+        "let $f := fn:function-lookup(xs:QName('xdmp:is-forwarded'),0)\n" +
+        "return if (exists($f)) then $f() " +
+        "else (" +
         "let $xdbcHeaderf := " +
         "fn:function-lookup(xs:QName('xdmp:get-xdbc-request-header'),1)\n" +
         "return if (exists($xdbcHeaderf)) " +
-        "then fn:exists($xdbcHeaderf('x-forwarded-for')) else false()";
+        "then fn:exists($xdbcHeaderf('x-forwarded-for')) else false())";
     
     protected AssignmentManager am = AssignmentManager.getInstance();
     protected boolean fastLoad;

--- a/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
+++ b/src/main/java/com/marklogic/mapreduce/MarkLogicInputFormat.java
@@ -318,7 +318,8 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
             StringBuilder buf = new StringBuilder();
             buf.append("xquery version \"1.0-ml\";\n");
             if (getForwardHeader) {
-                buf.append("fn:exists(xdmp:get-request-header('x-forwarded-for'));\n");
+                buf.append(ContentOutputFormat.HEADER_QUERY).append(";\n");
+                buf.append(ContentOutputFormat.XDBC_HEADER_QUERY).append(";\n");
             }
             buf.append("import module namespace hadoop = ");
             buf.append("\"http://marklogic.com/xdmp/hadoop\" at ");
@@ -401,6 +402,8 @@ extends InputFormat<KEYIN, VALUEIN> implements MarkLogicConstants {
                     ResultItem item = result.next();
                     if (getForwardHeader) {
                         forwardHeaderExists = item.asString().equals("true");
+                        item = result.next();
+                        forwardHeaderExists |= item.asString().equals("true");
                         item = result.next();
                         if (forwardHeaderExists) {
                             restrictHosts = true;


### PR DESCRIPTION
- Support isolated HTTP and XDBC requests by using the new xdmp buitlin `xdmp:is-isolated`
- Suport backward compatibility (new mlcp still works with old MarkLogic Server)